### PR TITLE
Initialize FairwayQuest CLI golf prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+**/bin/
+**/obj/
+*.user
+*.suo
+*.userprefs
+*.csproj.user
+*.DotSettings.user

--- a/FairwayQuest.sln
+++ b/FairwayQuest.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{526545A8-CCB5-47FE-AE05-A696EC09B701}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FairwayQuest.Core", "src\FairwayQuest.Core\FairwayQuest.Core.csproj", "{0E19C795-E2B3-48CE-B8F0-FED5E9A14B76}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FairwayQuest.Cli", "src\FairwayQuest.Cli\FairwayQuest.Cli.csproj", "{F9BE45F3-C09E-4171-AD07-F05C85DCC973}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{BA9325E2-E192-44FE-8DED-76A06BCCB8AB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FairwayQuest.Tests", "tests\FairwayQuest.Tests\FairwayQuest.Tests.csproj", "{796C8158-BD6E-4A82-ACDF-E7F5EA21C1DA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0E19C795-E2B3-48CE-B8F0-FED5E9A14B76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E19C795-E2B3-48CE-B8F0-FED5E9A14B76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E19C795-E2B3-48CE-B8F0-FED5E9A14B76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E19C795-E2B3-48CE-B8F0-FED5E9A14B76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9BE45F3-C09E-4171-AD07-F05C85DCC973}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9BE45F3-C09E-4171-AD07-F05C85DCC973}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9BE45F3-C09E-4171-AD07-F05C85DCC973}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9BE45F3-C09E-4171-AD07-F05C85DCC973}.Release|Any CPU.Build.0 = Release|Any CPU
+		{796C8158-BD6E-4A82-ACDF-E7F5EA21C1DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{796C8158-BD6E-4A82-ACDF-E7F5EA21C1DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{796C8158-BD6E-4A82-ACDF-E7F5EA21C1DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{796C8158-BD6E-4A82-ACDF-E7F5EA21C1DA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0E19C795-E2B3-48CE-B8F0-FED5E9A14B76} = {526545A8-CCB5-47FE-AE05-A696EC09B701}
+		{F9BE45F3-C09E-4171-AD07-F05C85DCC973} = {526545A8-CCB5-47FE-AE05-A696EC09B701}
+		{796C8158-BD6E-4A82-ACDF-E7F5EA21C1DA} = {BA9325E2-E192-44FE-8DED-76A06BCCB8AB}
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # FairwayQuest
-FairwayQuest is an open-source golf game experiment that blends strategy, skill, and a touch of adventure.
+
+FairwayQuest is a prototype command-line golf experience written in C#/.NET. It focuses on lightweight round simulation so gameplay rules, scoring models, and shot physics can be iterated on before a potential GUI build.
+
+## Getting Started
+
+```bash
+dotnet restore
+dotnet build
+dotnet test
+```
+
+Run the CLI round driver (prompts are interactive):
+
+```bash
+dotnet run --project src/FairwayQuest.Cli -- --seed 123 --fast
+```
+
+### CLI Options
+
+* `--seed <int>` – provide a deterministic random seed so the same inputs reproduce the same round (default `90210`).
+* `--fast` – trims some narration while keeping all essential prompts and outcomes.
+
+### Gameplay Flow
+
+1. Choose 1–4 players, enter their names and handicaps (0–54).
+2. Select 9 or 18 holes on the default course and pick *stroke* or *Stableford* scoring.
+3. Play hole-by-hole, selecting clubs when prompted. Enter `?` at any turn to see the club reference.
+4. After each shot an outcome line shows carry, lie, and distance to the pin. Putting resolves into 1–3 putts depending on distance.
+5. A final scoreboard summarises gross/net totals (stroke) or Stableford points and per-hole breakdowns.
+
+### Club Codes
+
+| Code | Club            | Typical Range |
+|------|-----------------|---------------|
+| D    | Driver          | 230–280 yds   |
+| 3w   | 3 Wood          | 210–240 yds   |
+| 5w   | 5 Wood          | 195–215 yds   |
+| 3i   | 3 Iron          | 180–200 yds   |
+| 4i   | 4 Iron          | 170–190 yds   |
+| 5i   | 5 Iron          | 160–180 yds   |
+| 6i   | 6 Iron          | 150–170 yds   |
+| 7i   | 7 Iron          | 140–160 yds   |
+| 8i   | 8 Iron          | 130–150 yds   |
+| 9i   | 9 Iron          | 120–140 yds   |
+| pw   | Pitching Wedge  | 95–115 yds    |
+| sw   | Sand Wedge      | 70–95 yds     |
+| lw   | Lob Wedge       | 40–70 yds     |
+| p    | Putter (green only) | — |
+
+### Simplified Physics Notes
+
+* Non-putter shots randomise around each club’s carry window and apply lie modifiers (rough −10%, bunker −15%).
+* Mishits (≈7%) and duffs (≈2%) drastically reduce carry for unpredictable moments.
+* Landing lie probabilities favour the fairway; shorter approaches can hold the green.
+* Putting resolves probabilistically within distance bands (tap-ins, makeable range, long lag putts).
+
+### Next Steps
+
+* Swap in data-driven course definitions (JSON) and support multiple layouts.
+* Expand shot physics with wind, elevation, and spin models.
+* Build a GUI layer once the simulation stabilises.

--- a/src/FairwayQuest.Cli/FairwayQuest.Cli.csproj
+++ b/src/FairwayQuest.Cli/FairwayQuest.Cli.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\FairwayQuest.Core\FairwayQuest.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/FairwayQuest.Cli/Program.cs
+++ b/src/FairwayQuest.Cli/Program.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FairwayQuest.Core.Courses;
+using FairwayQuest.Core.Models;
+using FairwayQuest.Core.Scoring;
+using FairwayQuest.Core.Simulation;
+using FairwayQuest.Core.Validation;
+
+var options = ParseOptions(args);
+var rng = new RandomNumberGeneratorAdapter(new Random(options.Seed));
+var shotEngine = new ShotEngine();
+
+Console.WriteLine("Welcome to FairwayQuest!");
+Console.WriteLine(options.FastMode
+    ? "Fast mode is enabled. Essential information will be displayed."
+    : "Enjoy a narrated round with full commentary.");
+
+var playerCount = PromptForValue<int>("Enter number of players (1-4): ", InputParsers.TryParsePlayerCount);
+var players = new List<Player>();
+for (var i = 0; i < playerCount; i++)
+{
+    var name = PromptForNonEmpty($"Player {i + 1} name: ");
+    var handicap = PromptForValue<int>($"{name}'s handicap (0-54): ", InputParsers.TryParseHandicap);
+    players.Add(new Player { Name = name, Handicap = handicap });
+}
+
+var holeCount = PromptForValue<int>("Number of holes (9 or 18): ", InputParsers.TryParseHoleCount);
+var gameType = PromptForValue<GameType>("Game type (stroke/stableford): ", InputParsers.TryParseGameType);
+
+var course = DefaultCourseProvider.CreateCourse(holeCount);
+foreach (var player in players)
+{
+    var allocation = HandicapAllocator.Allocate(player.Handicap, course);
+    player.SetAllocatedStrokes(allocation);
+}
+
+var playerStates = players.Select(player => new PlayerRoundState(player)).ToList();
+
+for (var holeIndex = 0; holeIndex < course.Count; holeIndex++)
+{
+    var hole = course[holeIndex];
+    Console.WriteLine();
+    Console.WriteLine($"=== Hole {hole.Number} | Par {hole.Par} | {hole.Yardage}y ===");
+    DisplayStandings(playerStates, gameType, options.FastMode);
+
+    foreach (var state in playerStates)
+    {
+        state.BeginHole(hole);
+        Console.WriteLine($"{state.Player.Name} starts {hole.Yardage}y away on a par {hole.Par}.");
+
+        while (!state.HoleComplete)
+        {
+            var banner = $"[{state.Player.Name}] Hole {hole.Number} | Par {hole.Par} | {hole.Yardage}y | Remaining {Math.Round(state.CurrentShotState.RemainingYards)}y | Lie {state.CurrentShotState.Lie}";
+            Console.WriteLine(banner);
+            var club = PromptForClub(state.CurrentShotState.IsOnGreen);
+            var outcome = shotEngine.ExecuteShot(state.CurrentShotState, club, rng);
+            state.ApplyShot(outcome);
+            Console.WriteLine(outcome.Description);
+        }
+
+        state.CompleteHole(hole, gameType);
+    }
+}
+
+Console.WriteLine();
+Console.WriteLine("=== Final Scoreboard ===");
+PrintFinalScoreboard(playerStates, course, gameType);
+
+return;
+
+static string PromptForClub(bool onGreen)
+{
+    while (true)
+    {
+        Console.Write("Select club (? for list): ");
+        var input = Console.ReadLine() ?? string.Empty;
+        if (input.Trim() == "?")
+        {
+            Console.WriteLine("Available clubs: " + string.Join(", ", ClubCatalog.NonPutterCodes) + ", p (green only)");
+            continue;
+        }
+
+        if (InputParsers.TryParseClub(input, onGreen, out var club))
+        {
+            return club;
+        }
+
+        Console.WriteLine(onGreen ? "Use 'p' when putting." : "Enter a valid club code (e.g., D, 7i, pw).");
+    }
+}
+
+static T PromptForValue<T>(string prompt, TryParseDelegate<T> parser)
+{
+    while (true)
+    {
+        Console.Write(prompt);
+        var input = Console.ReadLine();
+        if (parser(input, out var value))
+        {
+            return value;
+        }
+
+        Console.WriteLine("Invalid input. Please try again.");
+    }
+}
+
+static string PromptForNonEmpty(string prompt)
+{
+    while (true)
+    {
+        Console.Write(prompt);
+        var input = Console.ReadLine();
+        if (!string.IsNullOrWhiteSpace(input))
+        {
+            return input.Trim();
+        }
+
+        Console.WriteLine("Value cannot be empty.");
+    }
+}
+
+static void DisplayStandings(IEnumerable<PlayerRoundState> players, GameType gameType, bool fastMode)
+{
+    Console.WriteLine(fastMode ? "Standings:" : "Current standings before this hole:");
+    foreach (var state in players)
+    {
+        if (gameType == GameType.Stroke)
+        {
+            var gross = state.TotalGross;
+            var parSoFar = state.TotalParPlayed;
+            var relative = parSoFar == 0 ? 0 : gross - parSoFar;
+            var net = state.TotalNet;
+            var netRelative = parSoFar == 0 ? 0 : net - parSoFar;
+            Console.WriteLine($" - {state.Player.Name}: {gross} strokes ({FormatRelative(relative)}) | Net {net} ({FormatRelative(netRelative)})");
+        }
+        else
+        {
+            Console.WriteLine($" - {state.Player.Name}: {state.TotalStablefordPoints} pts");
+        }
+    }
+}
+
+static void PrintFinalScoreboard(IEnumerable<PlayerRoundState> players, IReadOnlyList<Hole> course, GameType gameType)
+{
+    if (gameType == GameType.Stroke)
+    {
+        var totalPar = course.Sum(h => h.Par);
+        Console.WriteLine($"{"Player",-15} {"Gross",5} {"Net",5} {"±Gross",8} {"±Net",6}");
+        foreach (var state in players)
+        {
+            var gross = state.TotalGross;
+            var net = state.TotalNet;
+            var grossRelative = gross - totalPar;
+            var netRelative = net - totalPar;
+            Console.WriteLine($"{state.Player.Name,-15} {gross,5} {net,5} {FormatRelative(grossRelative),8} {FormatRelative(netRelative),6}");
+        }
+    }
+    else
+    {
+        Console.WriteLine($"{"Player",-15} {"Pts",5} | Per-hole points");
+        foreach (var state in players)
+        {
+            var perHole = string.Join(" ", state.StablefordPoints.Select(p => p.ToString().PadLeft(2)));
+            Console.WriteLine($"{state.Player.Name,-15} {state.TotalStablefordPoints,5} | {perHole}");
+        }
+    }
+}
+
+static string FormatRelative(int relative)
+{
+    return relative switch
+    {
+        < 0 => relative.ToString(),
+        > 0 => $"+{relative}",
+        _ => "E"
+    };
+}
+
+static CliOptions ParseOptions(string[] args)
+{
+    var options = new CliOptions();
+    for (var i = 0; i < args.Length; i++)
+    {
+        var arg = args[i];
+        switch (arg)
+        {
+            case "--seed":
+                if (i + 1 >= args.Length || !int.TryParse(args[i + 1], out var seed))
+                {
+                    throw new ArgumentException("--seed requires an integer value");
+                }
+
+                options.Seed = seed;
+                i++;
+                break;
+            case "--fast":
+                options.FastMode = true;
+                break;
+            default:
+                throw new ArgumentException($"Unknown argument '{arg}'");
+        }
+    }
+
+    return options;
+}
+
+delegate bool TryParseDelegate<T>(string? input, out T value);
+
+sealed class CliOptions
+{
+    public int Seed { get; set; } = 90210;
+    public bool FastMode { get; set; }
+}
+
+sealed class PlayerRoundState
+{
+    private Hole? _currentHole;
+    private int _strokesThisHole;
+    private ShotState _currentState = ShotState.ForHoleStart(1);
+
+    public PlayerRoundState(Player player)
+    {
+        Player = player;
+    }
+
+    public Player Player { get; }
+    public List<int> GrossStrokes { get; } = new();
+    public List<int> NetStrokes { get; } = new();
+    public List<int> StablefordPoints { get; } = new();
+    public List<int> ParsPlayed { get; } = new();
+
+    public ShotState CurrentShotState => _currentState;
+    public bool HoleComplete => _currentHole is not null && _currentState.RemainingYards <= 0.5;
+    public int HolesCompleted => GrossStrokes.Count;
+    public int TotalGross => GrossStrokes.Sum();
+    public int TotalNet => NetStrokes.Sum();
+    public int TotalStablefordPoints => StablefordPoints.Sum();
+    public int TotalParPlayed => ParsPlayed.Sum();
+
+    public void BeginHole(Hole hole)
+    {
+        _currentHole = hole;
+        _currentState = ShotState.ForHoleStart(hole.Yardage);
+        _strokesThisHole = 0;
+    }
+
+    public void ApplyShot(ShotOutcome outcome)
+    {
+        _strokesThisHole += outcome.StrokesUsed;
+        _currentState = outcome.NewState;
+    }
+
+    public void CompleteHole(Hole hole, GameType gameType)
+    {
+        if (_currentHole is null)
+        {
+            return;
+        }
+
+        GrossStrokes.Add(_strokesThisHole);
+        ParsPlayed.Add(hole.Par);
+        var allocation = Player.AllocatedStrokesPerHole[hole.Number - 1];
+        var net = ScoreCalculator.CalculateNetStrokes(_strokesThisHole, allocation);
+        NetStrokes.Add(net);
+
+        if (gameType == GameType.Stableford)
+        {
+            var relative = net - hole.Par;
+            var points = ScoreCalculator.StablefordPointsFromRelativeScore(relative);
+            StablefordPoints.Add(points);
+            Console.WriteLine($"{Player.Name} earns {points} Stableford point(s).");
+        }
+        else
+        {
+            Console.WriteLine($"{Player.Name} records {_strokesThisHole} stroke(s). Net: {net}.");
+        }
+
+        _currentHole = null;
+        _strokesThisHole = 0;
+        _currentState = ShotState.ForHoleStart(1);
+    }
+}

--- a/src/FairwayQuest.Core/Courses/DefaultCourseProvider.cs
+++ b/src/FairwayQuest.Core/Courses/DefaultCourseProvider.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using FairwayQuest.Core.Models;
+
+namespace FairwayQuest.Core.Courses;
+
+public static class DefaultCourseProvider
+{
+    public static IReadOnlyList<Hole> CreateCourse(int holeCount)
+    {
+        return holeCount switch
+        {
+            9 => NineHoleCourse,
+            18 => EighteenHoleCourse,
+            _ => throw new ArgumentOutOfRangeException(nameof(holeCount), "Only 9 or 18 hole courses are supported.")
+        };
+    }
+
+    private static readonly List<Hole> NineHoleCourse = new()
+    {
+        new Hole { Number = 1, Par = 4, Yardage = 360, StrokeIndex = 4 },
+        new Hole { Number = 2, Par = 3, Yardage = 145, StrokeIndex = 8 },
+        new Hole { Number = 3, Par = 5, Yardage = 520, StrokeIndex = 2 },
+        new Hole { Number = 4, Par = 4, Yardage = 410, StrokeIndex = 6 },
+        new Hole { Number = 5, Par = 3, Yardage = 178, StrokeIndex = 7 },
+        new Hole { Number = 6, Par = 4, Yardage = 390, StrokeIndex = 3 },
+        new Hole { Number = 7, Par = 5, Yardage = 505, StrokeIndex = 1 },
+        new Hole { Number = 8, Par = 3, Yardage = 150, StrokeIndex = 9 },
+        new Hole { Number = 9, Par = 4, Yardage = 430, StrokeIndex = 5 }
+    };
+
+    private static readonly List<Hole> EighteenHoleCourse = new()
+    {
+        new Hole { Number = 1, Par = 4, Yardage = 405, StrokeIndex = 10 },
+        new Hole { Number = 2, Par = 3, Yardage = 168, StrokeIndex = 16 },
+        new Hole { Number = 3, Par = 5, Yardage = 520, StrokeIndex = 4 },
+        new Hole { Number = 4, Par = 4, Yardage = 440, StrokeIndex = 2 },
+        new Hole { Number = 5, Par = 4, Yardage = 360, StrokeIndex = 12 },
+        new Hole { Number = 6, Par = 3, Yardage = 198, StrokeIndex = 14 },
+        new Hole { Number = 7, Par = 5, Yardage = 555, StrokeIndex = 6 },
+        new Hole { Number = 8, Par = 4, Yardage = 415, StrokeIndex = 8 },
+        new Hole { Number = 9, Par = 3, Yardage = 150, StrokeIndex = 18 },
+        new Hole { Number = 10, Par = 4, Yardage = 430, StrokeIndex = 9 },
+        new Hole { Number = 11, Par = 3, Yardage = 190, StrokeIndex = 15 },
+        new Hole { Number = 12, Par = 5, Yardage = 575, StrokeIndex = 3 },
+        new Hole { Number = 13, Par = 4, Yardage = 380, StrokeIndex = 11 },
+        new Hole { Number = 14, Par = 4, Yardage = 425, StrokeIndex = 7 },
+        new Hole { Number = 15, Par = 3, Yardage = 210, StrokeIndex = 17 },
+        new Hole { Number = 16, Par = 5, Yardage = 505, StrokeIndex = 5 },
+        new Hole { Number = 17, Par = 4, Yardage = 445, StrokeIndex = 1 },
+        new Hole { Number = 18, Par = 4, Yardage = 395, StrokeIndex = 13 }
+    };
+}

--- a/src/FairwayQuest.Core/FairwayQuest.Core.csproj
+++ b/src/FairwayQuest.Core/FairwayQuest.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/FairwayQuest.Core/Models/ClubDefinition.cs
+++ b/src/FairwayQuest.Core/Models/ClubDefinition.cs
@@ -1,0 +1,6 @@
+namespace FairwayQuest.Core.Models;
+
+public record ClubDefinition(string Code, int MinYards, int MaxYards)
+{
+    public int Midpoint => (MinYards + MaxYards) / 2;
+}

--- a/src/FairwayQuest.Core/Models/GameType.cs
+++ b/src/FairwayQuest.Core/Models/GameType.cs
@@ -1,0 +1,7 @@
+namespace FairwayQuest.Core.Models;
+
+public enum GameType
+{
+    Stroke,
+    Stableford
+}

--- a/src/FairwayQuest.Core/Models/Hole.cs
+++ b/src/FairwayQuest.Core/Models/Hole.cs
@@ -1,0 +1,9 @@
+namespace FairwayQuest.Core.Models;
+
+public class Hole
+{
+    public required int Number { get; init; }
+    public required int Par { get; init; }
+    public required int Yardage { get; init; }
+    public required int StrokeIndex { get; init; }
+}

--- a/src/FairwayQuest.Core/Models/Lie.cs
+++ b/src/FairwayQuest.Core/Models/Lie.cs
@@ -1,0 +1,10 @@
+namespace FairwayQuest.Core.Models;
+
+public enum Lie
+{
+    Tee,
+    Fairway,
+    Rough,
+    Bunker,
+    Green
+}

--- a/src/FairwayQuest.Core/Models/Player.cs
+++ b/src/FairwayQuest.Core/Models/Player.cs
@@ -1,0 +1,16 @@
+namespace FairwayQuest.Core.Models;
+
+public class Player
+{
+    public required string Name { get; init; }
+
+    public required int Handicap { get; init; }
+
+    public int[] AllocatedStrokesPerHole { get; private set; } = Array.Empty<int>();
+
+    public void SetAllocatedStrokes(int[] strokes)
+    {
+        ArgumentNullException.ThrowIfNull(strokes);
+        AllocatedStrokesPerHole = strokes;
+    }
+}

--- a/src/FairwayQuest.Core/Models/ShotOutcome.cs
+++ b/src/FairwayQuest.Core/Models/ShotOutcome.cs
@@ -1,0 +1,3 @@
+namespace FairwayQuest.Core.Models;
+
+public record ShotOutcome(ShotState NewState, int StrokesUsed, string Description, bool Holed);

--- a/src/FairwayQuest.Core/Models/ShotState.cs
+++ b/src/FairwayQuest.Core/Models/ShotState.cs
@@ -1,0 +1,8 @@
+namespace FairwayQuest.Core.Models;
+
+public record ShotState(double RemainingYards, Lie Lie)
+{
+    public bool IsOnGreen => Lie == Lie.Green;
+
+    public static ShotState ForHoleStart(int yardage) => new(yardage, Lie.Tee);
+}

--- a/src/FairwayQuest.Core/Scoring/HandicapAllocator.cs
+++ b/src/FairwayQuest.Core/Scoring/HandicapAllocator.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using FairwayQuest.Core.Models;
+
+namespace FairwayQuest.Core.Scoring;
+
+public static class HandicapAllocator
+{
+    public static int[] Allocate(int handicap, IReadOnlyList<Hole> holes)
+    {
+        ArgumentNullException.ThrowIfNull(holes);
+        if (handicap < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(handicap));
+        }
+
+        var count = holes.Count;
+        if (count == 0)
+        {
+            return Array.Empty<int>();
+        }
+
+        var strokes = new int[count];
+        if (handicap == 0)
+        {
+            return strokes;
+        }
+
+        var fullCycles = handicap / count;
+        var remainder = handicap % count;
+
+        for (var i = 0; i < count; i++)
+        {
+            strokes[i] = fullCycles;
+        }
+
+        if (remainder == 0)
+        {
+            return strokes;
+        }
+
+        var ordered = holes
+            .Select((hole, index) => (hole, index))
+            .OrderBy(tuple => tuple.hole.StrokeIndex)
+            .ToArray();
+
+        for (var i = 0; i < remainder; i++)
+        {
+            var (_, index) = ordered[i % ordered.Length];
+            strokes[index]++;
+        }
+
+        return strokes;
+    }
+}

--- a/src/FairwayQuest.Core/Scoring/ScoreCalculator.cs
+++ b/src/FairwayQuest.Core/Scoring/ScoreCalculator.cs
@@ -1,0 +1,20 @@
+namespace FairwayQuest.Core.Scoring;
+
+public static class ScoreCalculator
+{
+    public static int CalculateNetStrokes(int grossStrokes, int strokesReceived) => grossStrokes - strokesReceived;
+
+    public static int StablefordPointsFromRelativeScore(int relativeToPar)
+    {
+        return relativeToPar switch
+        {
+            <= -4 => 6,
+            -3 => 5,
+            -2 => 4,
+            -1 => 3,
+            0 => 2,
+            1 => 1,
+            >= 2 => 0
+        };
+    }
+}

--- a/src/FairwayQuest.Core/Simulation/ClubCatalog.cs
+++ b/src/FairwayQuest.Core/Simulation/ClubCatalog.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using FairwayQuest.Core.Models;
+
+namespace FairwayQuest.Core.Simulation;
+
+public static class ClubCatalog
+{
+    private static readonly Dictionary<string, ClubDefinition> Clubs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["D"] = new("D", 230, 280),
+        ["3w"] = new("3w", 210, 240),
+        ["5w"] = new("5w", 195, 215),
+        ["3i"] = new("3i", 180, 200),
+        ["4i"] = new("4i", 170, 190),
+        ["5i"] = new("5i", 160, 180),
+        ["6i"] = new("6i", 150, 170),
+        ["7i"] = new("7i", 140, 160),
+        ["8i"] = new("8i", 130, 150),
+        ["9i"] = new("9i", 120, 140),
+        ["pw"] = new("pw", 95, 115),
+        ["sw"] = new("sw", 70, 95),
+        ["lw"] = new("lw", 40, 70),
+        ["p"] = new("p", 1, 1)
+    };
+
+    public static IReadOnlyCollection<ClubDefinition> AllClubs => Clubs.Values;
+
+    public static bool TryGetClub(string input, out ClubDefinition definition)
+    {
+        return Clubs.TryGetValue(input.Trim(), out definition!);
+    }
+
+    public static IEnumerable<string> NonPutterCodes => Clubs.Keys.Where(k => !string.Equals(k, "p", StringComparison.OrdinalIgnoreCase)).OrderBy(k => k);
+}

--- a/src/FairwayQuest.Core/Simulation/IRandomNumberGenerator.cs
+++ b/src/FairwayQuest.Core/Simulation/IRandomNumberGenerator.cs
@@ -1,0 +1,7 @@
+namespace FairwayQuest.Core.Simulation;
+
+public interface IRandomNumberGenerator
+{
+    double NextDouble();
+    int Next(int minInclusive, int maxExclusive);
+}

--- a/src/FairwayQuest.Core/Simulation/RandomNumberGeneratorAdapter.cs
+++ b/src/FairwayQuest.Core/Simulation/RandomNumberGeneratorAdapter.cs
@@ -1,0 +1,20 @@
+namespace FairwayQuest.Core.Simulation;
+
+public class RandomNumberGeneratorAdapter : IRandomNumberGenerator
+{
+    private readonly Random _random;
+
+    public RandomNumberGeneratorAdapter(int seed)
+    {
+        _random = new Random(seed);
+    }
+
+    public RandomNumberGeneratorAdapter(Random random)
+    {
+        _random = random;
+    }
+
+    public double NextDouble() => _random.NextDouble();
+
+    public int Next(int minInclusive, int maxExclusive) => _random.Next(minInclusive, maxExclusive);
+}

--- a/src/FairwayQuest.Core/Simulation/ShotEngine.cs
+++ b/src/FairwayQuest.Core/Simulation/ShotEngine.cs
@@ -1,0 +1,147 @@
+using System.Globalization;
+using FairwayQuest.Core.Models;
+
+namespace FairwayQuest.Core.Simulation;
+
+public class ShotEngine
+{
+    private const double MishitProbability = 0.07;
+    private const double DuffProbability = 0.02;
+
+    private const double RoughModifier = 0.9;
+    private const double BunkerModifier = 0.85;
+    private const double FairwayModifier = 1.0;
+    private const double TeeModifier = 1.0;
+
+    private const double CloseApproachThreshold = 8;
+    private const double GreenApproachThreshold = 30;
+
+    public ShotOutcome ExecuteShot(ShotState state, string clubInput, IRandomNumberGenerator rng)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clubInput);
+        ArgumentNullException.ThrowIfNull(rng);
+
+        var clubCode = clubInput.Trim();
+
+        if (state.IsOnGreen)
+        {
+            if (!string.Equals(clubCode, "p", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Only the putter can be used on the green.");
+            }
+
+            return SimulatePutt(state, rng);
+        }
+
+        if (!ClubCatalog.TryGetClub(clubCode, out var club))
+        {
+            throw new ArgumentException($"Unknown club '{clubInput}'.", nameof(clubInput));
+        }
+
+        if (string.Equals(club.Code, "p", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("Putter can only be used on the green.", nameof(clubInput));
+        }
+
+        var intended = SampleWithinRange(club.MinYards, club.MaxYards, rng);
+        var lieModifier = state.Lie switch
+        {
+            Lie.Tee => TeeModifier,
+            Lie.Fairway => FairwayModifier,
+            Lie.Rough => RoughModifier,
+            Lie.Bunker => BunkerModifier,
+            Lie.Green => FairwayModifier,
+            _ => 1.0
+        };
+
+        var mishitRoll = rng.NextDouble();
+        double mishitFactor = 1.0;
+        if (mishitRoll < DuffProbability)
+        {
+            mishitFactor = 0.05 + rng.NextDouble() * 0.15;
+        }
+        else if (mishitRoll < DuffProbability + MishitProbability)
+        {
+            mishitFactor = 0.35 + rng.NextDouble() * 0.25;
+        }
+
+        var carry = intended * lieModifier * mishitFactor;
+        var remaining = state.RemainingYards - carry;
+        var holed = remaining <= 0.5;
+        if (holed)
+        {
+            var description = $"{club.Code.ToLower(CultureInfo.InvariantCulture)} → holed";
+            return new ShotOutcome(new ShotState(0, Lie.Green), 1, description, true);
+        }
+
+        var adjustedRemaining = Math.Max(0.5, remaining);
+        var newLie = DetermineNextLie(state.Lie, adjustedRemaining, rng);
+        if (adjustedRemaining <= CloseApproachThreshold)
+        {
+            newLie = Lie.Green;
+        }
+
+        var descriptionLine = string.Format(CultureInfo.InvariantCulture,
+            "{0} → {1}y, {2}, {3}y to pin",
+            club.Code.ToLower(CultureInfo.InvariantCulture),
+            Math.Round(carry),
+            newLie.ToString().ToLower(CultureInfo.InvariantCulture),
+            Math.Round(adjustedRemaining));
+
+        return new ShotOutcome(new ShotState(adjustedRemaining, newLie), 1, descriptionLine, false);
+    }
+
+    private static ShotOutcome SimulatePutt(ShotState state, IRandomNumberGenerator rng)
+    {
+        var start = state.RemainingYards;
+        int putts;
+        if (start <= 2)
+        {
+            putts = rng.NextDouble() < 0.8 ? 1 : 2;
+        }
+        else if (start <= 8)
+        {
+            putts = rng.NextDouble() < 0.45 ? 1 : 2;
+        }
+        else
+        {
+            putts = rng.NextDouble() < 0.7 ? 2 : 3;
+        }
+
+        var description = $"p → holed ({putts} {(putts == 1 ? "putt" : "putts")})";
+        return new ShotOutcome(new ShotState(0, Lie.Green), putts, description, true);
+    }
+
+    private static double SampleWithinRange(double min, double max, IRandomNumberGenerator rng)
+    {
+        return min + (max - min) * rng.NextDouble();
+    }
+
+    private static Lie DetermineNextLie(Lie previousLie, double remaining, IRandomNumberGenerator rng)
+    {
+        if (remaining <= GreenApproachThreshold)
+        {
+            var roll = rng.NextDouble();
+            if (remaining <= CloseApproachThreshold || roll < 0.5)
+            {
+                return Lie.Green;
+            }
+
+            return roll < 0.8 ? Lie.Fairway : Lie.Rough;
+        }
+
+        var lieRoll = rng.NextDouble();
+        if (lieRoll < 0.7)
+        {
+            return Lie.Fairway;
+        }
+
+        if (lieRoll < 0.9)
+        {
+            return Lie.Rough;
+        }
+
+        return Lie.Bunker;
+    }
+}

--- a/src/FairwayQuest.Core/Validation/InputParsers.cs
+++ b/src/FairwayQuest.Core/Validation/InputParsers.cs
@@ -1,0 +1,121 @@
+using FairwayQuest.Core.Models;
+using FairwayQuest.Core.Simulation;
+
+namespace FairwayQuest.Core.Validation;
+
+public static class InputParsers
+{
+    public static bool TryParsePlayerCount(string? input, out int count)
+    {
+        count = 0;
+        if (!int.TryParse(input, out var parsed))
+        {
+            return false;
+        }
+
+        if (parsed is < 1 or > 4)
+        {
+            return false;
+        }
+
+        count = parsed;
+        return true;
+    }
+
+    public static bool TryParseHoleCount(string? input, out int holes)
+    {
+        holes = 0;
+        if (!int.TryParse(input, out var parsed))
+        {
+            return false;
+        }
+
+        if (parsed is not (9 or 18))
+        {
+            return false;
+        }
+
+        holes = parsed;
+        return true;
+    }
+
+    public static bool TryParseHandicap(string? input, out int handicap)
+    {
+        handicap = 0;
+        if (!int.TryParse(input, out var parsed))
+        {
+            return false;
+        }
+
+        if (parsed is < 0 or > 54)
+        {
+            return false;
+        }
+
+        handicap = parsed;
+        return true;
+    }
+
+    public static bool TryParseGameType(string? input, out GameType gameType)
+    {
+        gameType = GameType.Stroke;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        var normalized = input.Trim().ToLowerInvariant();
+        if (normalized == "stroke")
+        {
+            gameType = GameType.Stroke;
+            return true;
+        }
+
+        if (normalized == "stableford")
+        {
+            gameType = GameType.Stableford;
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool TryParseClub(string? input, bool onGreen, out string normalizedClub)
+    {
+        normalizedClub = string.Empty;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        var trimmed = input.Trim();
+        if (trimmed == "?")
+        {
+            return false;
+        }
+
+        if (onGreen)
+        {
+            if (string.Equals(trimmed, "p", StringComparison.OrdinalIgnoreCase))
+            {
+                normalizedClub = "p";
+                return true;
+            }
+
+            return false;
+        }
+
+        if (!ClubCatalog.TryGetClub(trimmed, out var club))
+        {
+            return false;
+        }
+
+        if (string.Equals(club.Code, "p", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        normalizedClub = club.Code;
+        return true;
+    }
+}

--- a/tests/FairwayQuest.Tests/FairwayQuest.Tests.csproj
+++ b/tests/FairwayQuest.Tests/FairwayQuest.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="8.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FairwayQuest.Core\FairwayQuest.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/FairwayQuest.Tests/GlobalUsings.cs
+++ b/tests/FairwayQuest.Tests/GlobalUsings.cs
@@ -1,0 +1,2 @@
+global using Xunit;
+global using FluentAssertions;

--- a/tests/FairwayQuest.Tests/Scoring/HandicapAllocatorTests.cs
+++ b/tests/FairwayQuest.Tests/Scoring/HandicapAllocatorTests.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+using FairwayQuest.Core.Courses;
+using FairwayQuest.Core.Scoring;
+
+namespace FairwayQuest.Tests.Scoring;
+
+public class HandicapAllocatorTests
+{
+    private static readonly IReadOnlyList<Core.Models.Hole> NineHoleCourse = DefaultCourseProvider.CreateCourse(9);
+    private static readonly IReadOnlyList<Core.Models.Hole> EighteenHoleCourse = DefaultCourseProvider.CreateCourse(18);
+
+    public static IEnumerable<object[]> NineHoleCases() => new List<object[]>
+    {
+        new object[] { 0, Enumerable.Repeat(0, 9).ToArray() },
+        new object[] { 9, Enumerable.Repeat(1, 9).ToArray() },
+        new object[] { 18, Enumerable.Repeat(2, 9).ToArray() },
+        new object[] { 36, Enumerable.Repeat(4, 9).ToArray() },
+        new object[] { 54, Enumerable.Repeat(6, 9).ToArray() }
+    };
+
+    public static IEnumerable<object[]> EighteenHoleCases()
+    {
+        yield return new object[] { 0, Enumerable.Repeat(0, 18).ToArray() };
+        yield return new object[] { 18, Enumerable.Repeat(1, 18).ToArray() };
+
+        var twenty = Enumerable.Repeat(1, 18).ToArray();
+        twenty[3]++;
+        twenty[16]++;
+        yield return new object[] { 20, twenty };
+
+        yield return new object[] { 36, Enumerable.Repeat(2, 18).ToArray() };
+        yield return new object[] { 54, Enumerable.Repeat(3, 18).ToArray() };
+    }
+
+    [Theory]
+    [MemberData(nameof(NineHoleCases))]
+    public void AllocatesExpectedStrokes_ForNineHoles(int handicap, int[] expected)
+    {
+        var result = HandicapAllocator.Allocate(handicap, NineHoleCourse);
+        result.Should().Equal(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(EighteenHoleCases))]
+    public void AllocatesExpectedStrokes_ForEighteenHoles(int handicap, int[] expected)
+    {
+        var result = HandicapAllocator.Allocate(handicap, EighteenHoleCourse);
+        result.Should().Equal(expected);
+    }
+}

--- a/tests/FairwayQuest.Tests/Scoring/StablefordPointsTests.cs
+++ b/tests/FairwayQuest.Tests/Scoring/StablefordPointsTests.cs
@@ -1,0 +1,21 @@
+using FairwayQuest.Core.Scoring;
+
+namespace FairwayQuest.Tests.Scoring;
+
+public class StablefordPointsTests
+{
+    [Theory]
+    [InlineData(2, 0)]
+    [InlineData(1, 1)]
+    [InlineData(0, 2)]
+    [InlineData(-1, 3)]
+    [InlineData(-2, 4)]
+    [InlineData(-3, 5)]
+    [InlineData(-4, 6)]
+    [InlineData(-5, 6)]
+    public void MapsRelativeScoreToStablefordPoints(int relative, int expected)
+    {
+        var result = ScoreCalculator.StablefordPointsFromRelativeScore(relative);
+        result.Should().Be(expected);
+    }
+}

--- a/tests/FairwayQuest.Tests/Simulation/FakeRandomNumberGenerator.cs
+++ b/tests/FairwayQuest.Tests/Simulation/FakeRandomNumberGenerator.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using FairwayQuest.Core.Simulation;
+
+namespace FairwayQuest.Tests.Simulation;
+
+public class FakeRandomNumberGenerator : IRandomNumberGenerator
+{
+    private readonly Queue<double> _doubleValues;
+    private readonly Queue<int> _intValues;
+
+    public FakeRandomNumberGenerator(IEnumerable<double>? doubles = null, IEnumerable<int>? ints = null)
+    {
+        _doubleValues = new Queue<double>(doubles ?? Array.Empty<double>());
+        _intValues = new Queue<int>(ints ?? Array.Empty<int>());
+    }
+
+    public double NextDouble()
+    {
+        if (_doubleValues.Count == 0)
+        {
+            throw new InvalidOperationException("No more double values configured.");
+        }
+
+        return _doubleValues.Dequeue();
+    }
+
+    public int Next(int minInclusive, int maxExclusive)
+    {
+        if (_intValues.Count == 0)
+        {
+            throw new InvalidOperationException("No more int values configured.");
+        }
+
+        return _intValues.Dequeue();
+    }
+}

--- a/tests/FairwayQuest.Tests/Simulation/ShotEngineTests.cs
+++ b/tests/FairwayQuest.Tests/Simulation/ShotEngineTests.cs
@@ -1,0 +1,76 @@
+using FairwayQuest.Core.Models;
+using FairwayQuest.Core.Simulation;
+
+namespace FairwayQuest.Tests.Simulation;
+
+public class ShotEngineTests
+{
+    [Fact]
+    public void ShotsFromRoughTravelLessThanFairway()
+    {
+        var engine = new ShotEngine();
+        var commonSequence = new[] { 0.5, 0.5, 0.6 };
+
+        var fairwayOutcome = engine.ExecuteShot(new ShotState(160, Lie.Fairway), "7i", new FakeRandomNumberGenerator(commonSequence));
+        var roughOutcome = engine.ExecuteShot(new ShotState(160, Lie.Rough), "7i", new FakeRandomNumberGenerator(commonSequence));
+
+        roughOutcome.NewState.RemainingYards.Should().BeGreaterThan(fairwayOutcome.NewState.RemainingYards);
+    }
+
+    [Fact]
+    public void ShortPuttsCanFinishInSinglePutt()
+    {
+        var engine = new ShotEngine();
+        var outcome = engine.ExecuteShot(new ShotState(2, Lie.Green), "p", new FakeRandomNumberGenerator(new[] { 0.1 }));
+        outcome.StrokesUsed.Should().Be(1);
+        outcome.Holed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShortPuttsMayRequireTwoPutts()
+    {
+        var engine = new ShotEngine();
+        var outcome = engine.ExecuteShot(new ShotState(2, Lie.Green), "p", new FakeRandomNumberGenerator(new[] { 0.95 }));
+        outcome.StrokesUsed.Should().Be(2);
+    }
+
+    [Fact]
+    public void LongPuttsCanTakeThreeStrokes()
+    {
+        var engine = new ShotEngine();
+        var outcome = engine.ExecuteShot(new ShotState(12, Lie.Green), "p", new FakeRandomNumberGenerator(new[] { 0.95 }));
+        outcome.StrokesUsed.Should().Be(3);
+    }
+
+    [Fact]
+    public void SeededRandomProducesDeterministicOutcomes()
+    {
+        var engine = new ShotEngine();
+        var seed = 424242;
+        var clubs = new[] { "d", "7i", "sw", "p" };
+
+        var rngOne = new RandomNumberGeneratorAdapter(new Random(seed));
+        var rngTwo = new RandomNumberGeneratorAdapter(new Random(seed));
+
+        var stateOne = ShotState.ForHoleStart(420);
+        var stateTwo = ShotState.ForHoleStart(420);
+
+        foreach (var club in clubs)
+        {
+            var outcomeOne = engine.ExecuteShot(stateOne, club, rngOne);
+            var outcomeTwo = engine.ExecuteShot(stateTwo, club, rngTwo);
+
+            outcomeOne.Description.Should().Be(outcomeTwo.Description);
+            outcomeOne.NewState.Should().Be(outcomeTwo.NewState);
+            outcomeOne.StrokesUsed.Should().Be(outcomeTwo.StrokesUsed);
+
+            stateOne = outcomeOne.NewState;
+            stateTwo = outcomeTwo.NewState;
+
+            if (outcomeOne.Holed)
+            {
+                break;
+            }
+        }
+    }
+}

--- a/tests/FairwayQuest.Tests/Validation/InputParserTests.cs
+++ b/tests/FairwayQuest.Tests/Validation/InputParserTests.cs
@@ -1,0 +1,69 @@
+using FairwayQuest.Core.Models;
+using FairwayQuest.Core.Validation;
+
+namespace FairwayQuest.Tests.Validation;
+
+public class InputParserTests
+{
+    [Theory]
+    [InlineData("1", 1)]
+    [InlineData("4", 4)]
+    public void PlayerCount_AllowsValuesBetweenOneAndFour(string input, int expected)
+    {
+        InputParsers.TryParsePlayerCount(input, out var result).Should().BeTrue();
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("5")]
+    [InlineData("abc")]
+    public void PlayerCount_RejectsInvalidEntries(string input)
+    {
+        InputParsers.TryParsePlayerCount(input, out _).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("9", 9)]
+    [InlineData("18", 18)]
+    public void HoleCount_AcceptsNineOrEighteen(string input, int expected)
+    {
+        InputParsers.TryParseHoleCount(input, out var result).Should().BeTrue();
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("8")]
+    [InlineData("20")]
+    [InlineData("" )]
+    public void HoleCount_RejectsOtherValues(string input)
+    {
+        InputParsers.TryParseHoleCount(input, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ClubParsing_IsCaseInsensitive()
+    {
+        InputParsers.TryParseClub("7I", false, out var club).Should().BeTrue();
+        club.Should().Be("7i");
+    }
+
+    [Fact]
+    public void ClubParsing_RejectsPutterOffGreen()
+    {
+        InputParsers.TryParseClub("p", false, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ClubParsing_AllowsPutterOnGreen()
+    {
+        InputParsers.TryParseClub("P", true, out var club).Should().BeTrue();
+        club.Should().Be("p");
+    }
+
+    [Fact]
+    public void ClubParsing_RejectsUnknownCode()
+    {
+        InputParsers.TryParseClub("xx", false, out _).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- create the FairwayQuest solution with core library, CLI runner, and xUnit test project
- implement course data, handicap allocation, scoring helpers, and the shot engine that powers the interactive round flow
- document build/run steps and add tests for handicapping, stableford scoring, club parsing, and shot behaviour

## Testing
- dotnet build
- dotnet test
- dotnet run --project src/FairwayQuest.Cli -- --seed 123 --fast

------
https://chatgpt.com/codex/tasks/task_e_68dd2b9160688330ab4ca46e425cfbb3