### PR TITLE
Refactor round flow for single-responsibility methods

### DIFF
--- a/src/FairwayQuest.Cli/src/AppOptions.cs
+++ b/src/FairwayQuest.Cli/src/AppOptions.cs
@@ -1,0 +1,16 @@
+namespace FairwayQuest.Cli;
+
+/// <summary>
+/// Captures command-line options influencing gameplay.
+/// </summary>
+internal sealed class AppOptions
+{
+    /// <summary>Gets the deterministic seed value.</summary>
+    public int? Seed { get; init; }
+
+    /// <summary>Gets a value indicating whether narration should be condensed.</summary>
+    public bool FastMode { get; init; }
+
+    /// <summary>Gets a value indicating whether auto-play is enabled.</summary>
+    public bool AutoPlay { get; init; }
+}

--- a/src/FairwayQuest.Cli/src/Application.cs
+++ b/src/FairwayQuest.Cli/src/Application.cs
@@ -1,0 +1,248 @@
+namespace FairwayQuest.Cli;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using FairwayQuest.Cli.Round;
+using FairwayQuest.Core.Abstractions;
+using FairwayQuest.Core.Allocation;
+using FairwayQuest.Core.Gameplay;
+using FairwayQuest.Core.Handicapping;
+using FairwayQuest.Core.Models;
+using FairwayQuest.Core.Scoring;
+using FairwayQuest.Core.Shots;
+using GameplayRound = FairwayQuest.Core.Gameplay.Round;
+
+#pragma warning disable CA1303 // CLI intentionally writes literal strings to the console.
+
+/// <summary>
+/// Console application orchestrating interactive FairwayQuest rounds.
+/// </summary>
+internal sealed class Application
+{
+    private readonly ICourseRepository courseRepository;
+    private readonly IRandomProvider randomProvider;
+    private readonly AppOptions options;
+    private readonly ShotEngine shotEngine = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Application"/> class.
+    /// </summary>
+    /// <param name="courseRepository">Course repository supplying available courses.</param>
+    /// <param name="randomProvider">Random provider for deterministic simulations.</param>
+    /// <param name="options">Command-line options.</param>
+    public Application(ICourseRepository courseRepository, IRandomProvider randomProvider, AppOptions options)
+    {
+        this.courseRepository = courseRepository;
+        this.randomProvider = randomProvider;
+        this.options = options;
+    }
+
+    /// <summary>
+    /// Executes the CLI workflow.
+    /// </summary>
+    /// <returns>A task representing asynchronous execution.</returns>
+    public async Task RunAsync()
+    {
+        Console.WriteLine("FairwayQuest — Shot-by-Shot Edition");
+        Console.WriteLine();
+
+        var courses = await this.courseRepository.GetCoursesAsync().ConfigureAwait(false);
+        if (courses.Count == 0)
+        {
+            Console.WriteLine("No courses available.");
+            return;
+        }
+
+        var course = this.PromptForCourse(courses);
+        var holeSelection = this.PromptForHoleSelection();
+        var holes = course.SelectHoles(holeSelection);
+        var format = this.PromptForFormat();
+        var players = this.CollectPlayers(course, holes, format);
+
+        this.PrintRoundSummary(course, holes, format, players, holeSelection);
+        var round = new GameplayRound(course, holes, players, format);
+        var runner = new RoundRunner(round, this.shotEngine, this.randomProvider, this.options);
+        var trackers = runner.PlayRound();
+        this.PrintFinalScores(round, trackers);
+    }
+
+    private Course PromptForCourse(IReadOnlyList<Course> courses)
+    {
+        for (var i = 0; i < courses.Count; i++)
+        {
+            Console.WriteLine($"[{i + 1}] {courses[i].Name} ({courses[i].Location})");
+        }
+
+        Console.Write($"Select course (1-{courses.Count}): ");
+        var index = this.ReadInt(value => value >= 1 && value <= courses.Count) - 1;
+        return courses[index];
+    }
+
+    private HoleSelection PromptForHoleSelection()
+    {
+        Console.WriteLine("Holes to play: [1] 18, [2] Front 9, [3] Back 9");
+        Console.Write("Selection: ");
+        return this.ReadInt(value => value is >= 1 and <= 3) switch
+        {
+            1 => HoleSelection.All18,
+            2 => HoleSelection.Front9,
+            _ => HoleSelection.Back9,
+        };
+    }
+
+    private GameFormat PromptForFormat()
+    {
+        Console.WriteLine("Format: [1] Stroke play, [2] Stableford");
+        Console.Write("Selection: ");
+        return this.ReadInt(value => value is 1 or 2) == 1 ? GameFormat.StrokePlay : GameFormat.Stableford;
+    }
+
+    private List<Player> CollectPlayers(Course course, IReadOnlyList<Hole> holes, GameFormat format)
+    {
+        Console.WriteLine();
+        Console.Write("How many players (1-4)? ");
+        var playerCount = this.ReadInt(value => value is >= 1 and <= 4);
+        var strokeIndexes = StrokeIndexMapper.MapMenStrokeIndexes(holes);
+        var players = new List<Player>(playerCount);
+
+        for (var i = 0; i < playerCount; i++)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Player {i + 1}");
+            Console.Write("Name: ");
+            var name = this.ReadRequiredString();
+            Console.Write("Handicap (0-54): ");
+            var handicap = this.ReadInt(value => value is >= 0 and <= 54);
+            var tee = this.PromptForTee(course);
+            var eph = EffectiveHandicapCalculator.ComputeEffectivePlayingHandicap(
+                handicap,
+                format == GameFormat.Stableford,
+                holes.Count);
+            var allocations = StrokeAllocator.Allocate(eph, strokeIndexes);
+            players.Add(new Player(name, handicap, tee, eph, allocations));
+        }
+
+        return players;
+    }
+
+    private string PromptForTee(Course course)
+    {
+        Console.WriteLine("Tees:");
+        foreach (var tee in course.TeesMetadata.Keys)
+        {
+            Console.WriteLine($" - {tee}");
+        }
+
+        Console.Write($"Tee (Enter for {course.DefaultTee}): ");
+        var input = Console.ReadLine();
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return course.DefaultTee;
+        }
+
+        var value = input.Trim();
+        while (!course.TeesMetadata.ContainsKey(value))
+        {
+            Console.Write("Unknown tee, try again: ");
+            value = this.ReadRequiredString();
+        }
+
+        return value;
+    }
+
+    private void PrintRoundSummary(
+        Course course,
+        IReadOnlyList<Hole> holes,
+        GameFormat format,
+        IReadOnlyList<Player> players,
+        HoleSelection selection)
+    {
+        Console.WriteLine();
+        Console.WriteLine("=== Round Summary ===");
+        Console.WriteLine($"Course: {course.Name} ({course.Location})");
+        Console.WriteLine($"Holes: {this.DescribeSelection(selection)} ({holes.Count})");
+        Console.WriteLine($"Format: {format}");
+        Console.WriteLine();
+
+        foreach (var player in players)
+        {
+            Console.WriteLine($"{player.Name} — Tee {player.Tee} | HI {player.HandicapIndex18} → EPH {player.EffectivePlayingHandicap}");
+            Console.WriteLine($"Strokes: {string.Join(", ", player.AllocatedStrokesPerHole)}");
+            Console.WriteLine();
+        }
+    }
+
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Instance method keeps structure uniform for potential overrides.")]
+    private string DescribeSelection(HoleSelection selection)
+    {
+        return selection switch
+        {
+            HoleSelection.All18 => "Full 18",
+            HoleSelection.Front9 => "Front 9",
+            HoleSelection.Back9 => "Back 9",
+            _ => selection.ToString(),
+        };
+    }
+
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Instance method keeps access to options if future logic requires it.")]
+    private void PrintFinalScores(GameplayRound round, IReadOnlyList<PlayerRoundTracker> trackers)
+    {
+        Console.WriteLine();
+        Console.WriteLine("=== Final Scoreboard ===");
+
+        if (round.Format == GameFormat.Stableford)
+        {
+            foreach (var tracker in trackers.OrderByDescending(t => t.TotalStablefordPoints))
+            {
+                Console.WriteLine($"{tracker.Player.Name}: {tracker.TotalStablefordPoints} pts | {string.Join(" ", tracker.StablefordPerHole)}");
+            }
+        }
+        else
+        {
+            var parTotal = round.Holes.Sum(hole => hole.Par);
+            foreach (var tracker in trackers.OrderBy(t => t.TotalNetStrokes))
+            {
+                var relative = tracker.TotalNetStrokes - parTotal;
+                var label = relative switch
+                {
+                    < 0 => $"{Math.Abs(relative)} under",
+                    0 => "even",
+                    _ => $"{relative} over",
+                };
+                Console.WriteLine($"{tracker.Player.Name}: Gross {tracker.TotalGrossStrokes}, Net {tracker.TotalNetStrokes} ({label})");
+            }
+        }
+    }
+
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Instance form eases future dependency injection for input.")]
+    private int ReadInt(Func<int, bool> predicate)
+    {
+        while (true)
+        {
+            var input = Console.ReadLine();
+            if (int.TryParse(input, out var value) && predicate(value))
+            {
+                return value;
+            }
+
+            Console.Write("Invalid value, try again: ");
+        }
+    }
+
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Instance form eases future dependency injection for input.")]
+    private string ReadRequiredString()
+    {
+        while (true)
+        {
+            var input = Console.ReadLine();
+            if (!string.IsNullOrWhiteSpace(input))
+            {
+                return input.Trim();
+            }
+
+            Console.Write("Required: ");
+        }
+    }
+}
+
+#pragma warning restore CA1303

--- a/src/FairwayQuest.Cli/src/ArgumentParser.cs
+++ b/src/FairwayQuest.Cli/src/ArgumentParser.cs
@@ -1,0 +1,61 @@
+namespace FairwayQuest.Cli;
+
+/// <summary>
+/// Parses command-line arguments into <see cref="AppOptions"/>.
+/// </summary>
+internal static class ArgumentParser
+{
+    /// <summary>
+    /// Parses the provided argument array.
+    /// </summary>
+    /// <param name="args">Raw command-line arguments.</param>
+    /// <returns>Populated <see cref="AppOptions"/>.</returns>
+    public static AppOptions Parse(string[] args)
+    {
+        var options = new AppOptions();
+        if (args.Length == 0)
+        {
+            return options;
+        }
+
+        var seedValue = default(int?);
+        var fast = false;
+        var auto = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var argument = args[i];
+            switch (argument)
+            {
+                case "--seed":
+                    if (i + 1 >= args.Length)
+                    {
+                        throw new ArgumentException("--seed requires a numeric value.");
+                    }
+
+                    if (!int.TryParse(args[++i], out var parsedSeed))
+                    {
+                        throw new ArgumentException("--seed value must be an integer.");
+                    }
+
+                    seedValue = parsedSeed;
+                    break;
+                case "--fast":
+                    fast = true;
+                    break;
+                case "--auto":
+                    auto = true;
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown argument '{argument}'.");
+            }
+        }
+
+        return new AppOptions
+        {
+            Seed = seedValue,
+            FastMode = fast,
+            AutoPlay = auto,
+        };
+    }
+}

--- a/src/FairwayQuest.Cli/src/AssemblyInfo.cs
+++ b/src/FairwayQuest.Cli/src/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("FairwayQuest.Tests")]

--- a/src/FairwayQuest.Cli/src/Program.cs
+++ b/src/FairwayQuest.Cli/src/Program.cs
@@ -1,35 +1,51 @@
 namespace FairwayQuest.Cli;
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using FairwayQuest.Courses;
+using System.Diagnostics.CodeAnalysis;
+using FairwayQuest.Cli.Random;
 using FairwayQuest.Core.Abstractions;
-using FairwayQuest.Core.Allocation;
-using FairwayQuest.Core.Handicapping;
-using FairwayQuest.Core.Models;
-using FairwayQuest.Core.Scoring;
+using FairwayQuest.Courses;
 
+#pragma warning disable CA1303 // CLI outputs literal strings by design.
+
+/// <summary>
+/// Entry point for the FairwayQuest command-line application.
+/// </summary>
 internal static class Program
 {
-    private static async Task<int> Main()
+    /// <summary>
+    /// Application entry point.
+    /// </summary>
+    /// <param name="args">Command-line arguments.</param>
+    /// <returns>Zero for success; non-zero otherwise.</returns>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "CLI entry point surfaces user-friendly messages.")]
+    private static async Task<int> Main(string[] args)
     {
         try
         {
+            var options = ArgumentParser.Parse(args);
             var repository = new JsonCourseRepository(ResolveCoursesPath());
-            var app = new Application(repository);
-            await app.RunAsync().ConfigureAwait(false);
+            var randomProvider = new SeedRandomProvider(options.Seed);
+            var application = new Application(repository, randomProvider, options);
+            await application.RunAsync().ConfigureAwait(false);
             return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            await Console.Out.WriteLineAsync(string.Empty).ConfigureAwait(false);
+            await Console.Out.WriteLineAsync("Round aborted.").ConfigureAwait(false);
+            return 1;
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Error: {ex.Message}");
+            await Console.Error.WriteLineAsync($"Error: {ex.Message}").ConfigureAwait(false);
             return 1;
         }
     }
 
+    /// <summary>
+    /// Determines the directory containing course JSON files.
+    /// </summary>
+    /// <returns>The resolved path.</returns>
     private static string ResolveCoursesPath()
     {
         var candidates = new[]
@@ -49,279 +65,6 @@ internal static class Program
 
         return candidates[0];
     }
-
-    private sealed class Application
-    {
-        private readonly ICourseRepository courseRepository;
-
-        public Application(ICourseRepository courseRepository)
-        {
-            this.courseRepository = courseRepository;
-        }
-
-        public async Task RunAsync()
-        {
-            Console.WriteLine("FairwayQuest - Handicap & Stableford Demo");
-            Console.WriteLine();
-
-            var courses = await courseRepository.GetCoursesAsync().ConfigureAwait(false);
-            if (courses.Count == 0)
-            {
-                Console.WriteLine("No courses available.");
-                return;
-            }
-
-            var course = PromptForCourse(courses);
-            var tee = PromptForTee(course);
-            var selection = PromptForHoleSelection();
-            var holes = course.SelectHoles(selection);
-            var format = PromptForFormat();
-
-            var players = CollectPlayers(format, holes);
-            DisplayRoundSummary(course, tee, selection, holes, players);
-            PlayRound(players, holes, format);
-            PrintFinalScores(players, format);
-        }
-
-        private static IReadOnlyList<PlayerRound> CollectPlayers(GameFormat format, IReadOnlyList<Hole> holes)
-        {
-            Console.WriteLine();
-            Console.Write("How many players (1-4)? ");
-            var playerCount = PromptForInt(value => value is >= 1 and <= 4);
-
-            var players = new List<PlayerRound>(playerCount);
-            for (var i = 0; i < playerCount; i++)
-            {
-                Console.Write($"Player {i + 1} name: ");
-                var name = PromptForNonEmpty();
-
-                Console.Write($"{name}'s handicap index (0-54): ");
-                var handicap = PromptForInt(value => value is >= 0 and <= 54);
-
-                var effective = EffectiveHandicapCalculator.ComputeEffectivePlayingHandicap(
-                    handicap,
-                    format == GameFormat.Stableford,
-                    holes.Count);
-
-                var strokeIndexes = StrokeIndexMapper.MapMenStrokeIndexes(holes);
-                var allocations = StrokeAllocator.Allocate(effective, strokeIndexes);
-                players.Add(new PlayerRound(name, handicap, effective, allocations));
-            }
-
-            return players;
-        }
-
-        private static void DisplayRoundSummary(
-            Course course,
-            string tee,
-            HoleSelection selection,
-            IReadOnlyList<Hole> holes,
-            IReadOnlyList<PlayerRound> players)
-        {
-            Console.WriteLine();
-            Console.WriteLine($"Course: {course.Name} ({course.Location}) - Tee: {tee}");
-            Console.WriteLine($"Playing {DescribeSelection(selection)} ({holes.Count} holes)");
-            Console.WriteLine();
-
-            foreach (var player in players)
-            {
-                Console.WriteLine($"{player.Name}: HI={player.HandicapIndex} → EPH={player.EffectiveHandicap}");
-                Console.WriteLine($"Strokes per hole: {string.Join(", ", player.StrokesPerHole)}");
-                Console.WriteLine();
-            }
-        }
-
-        private static void PlayRound(IReadOnlyList<PlayerRound> players, IReadOnlyList<Hole> holes, GameFormat format)
-        {
-            for (var holeIndex = 0; holeIndex < holes.Count; holeIndex++)
-            {
-                var hole = holes[holeIndex];
-                Console.WriteLine($"Hole {hole.Number} (Par {hole.Par}, SI {hole.StrokeIndex.Men})");
-
-                foreach (var player in players)
-                {
-                    Console.Write($"  {player.Name} gross strokes: ");
-                    var gross = PromptForInt(value => value is > 0 and <= 20);
-                    var strokesReceived = player.StrokesPerHole[holeIndex];
-
-                    if (format == GameFormat.Stableford)
-                    {
-                        var result = ScoreCalculator.CalculateStableford(hole.Par, gross, strokesReceived);
-                        player.AddStablefordResult(result);
-                        Console.WriteLine($"    → Net {result.NetStrokes} ({DescribeRelative(result.NetStrokes - hole.Par)}) → {result.StablefordPoints} pts");
-                    }
-                    else
-                    {
-                        player.AddStrokePlayResult(gross, strokesReceived);
-                        Console.WriteLine($"    → Gross {gross} with {strokesReceived} stroke(s)");
-                    }
-                }
-
-                Console.WriteLine();
-            }
-        }
-
-        private static void PrintFinalScores(IReadOnlyList<PlayerRound> players, GameFormat format)
-        {
-            Console.WriteLine("=== Final Scores ===");
-            if (format == GameFormat.Stableford)
-            {
-                foreach (var player in players.OrderByDescending(p => p.TotalStablefordPoints))
-                {
-                    Console.WriteLine($"{player.Name}: {player.TotalStablefordPoints} points");
-                }
-            }
-            else
-            {
-                foreach (var player in players.OrderBy(p => p.TotalGrossStrokes))
-                {
-                    Console.WriteLine($"{player.Name}: Gross {player.TotalGrossStrokes}, Net {player.NetStrokePlayScore}");
-                }
-            }
-        }
-
-        private static string DescribeSelection(HoleSelection selection)
-        {
-            return selection switch
-            {
-                HoleSelection.All18 => "18 holes",
-                HoleSelection.Front9 => "Front 9",
-                HoleSelection.Back9 => "Back 9",
-                _ => selection.ToString(),
-            };
-        }
-
-        private static string DescribeRelative(int relative)
-        {
-            return relative switch
-            {
-                < 0 => $"{Math.Abs(relative)} under",
-                0 => "even",
-                _ => $"{relative} over",
-            };
-        }
-
-        private static Course PromptForCourse(IReadOnlyList<Course> courses)
-        {
-            if (courses is null || courses.Count == 0)
-                throw new ArgumentException("No courses available.", nameof(courses));
-
-            for (var i = 0; i < courses.Count; i++)
-                Console.WriteLine($"[{i + 1}] {courses[i].Name} ({courses[i].Location})");
-
-            Console.Write($"Select course (1–{courses.Count}): ");
-            var idx1Based = PromptForInt(v => v >= 1 && v <= courses.Count);
-            return courses[idx1Based - 1];
-        }
-
-        private static string PromptForTee(Course course)
-        {
-            Console.WriteLine("Available tees:");
-            foreach (var tee in course.TeesMetadata.Keys)
-            {
-                Console.WriteLine($" - {tee}");
-            }
-
-            Console.Write($"Choose tee (Enter for {course.DefaultTee}): ");
-            var input = Console.ReadLine();
-            if (string.IsNullOrWhiteSpace(input))
-            {
-                return course.DefaultTee;
-            }
-
-            var trimmed = input.Trim();
-            while (!course.TeesMetadata.ContainsKey(trimmed))
-            {
-                Console.Write("Unknown tee. Try again: ");
-                trimmed = PromptForNonEmpty();
-            }
-
-            return trimmed;
-        }
-
-        private static HoleSelection PromptForHoleSelection()
-        {
-            Console.WriteLine("Holes to play: [1] 18, [2] Front 9, [3] Back 9");
-            Console.Write("Selection: ");
-            return PromptForInt(value => value is >= 1 and <= 3) switch
-            {
-                1 => HoleSelection.All18,
-                2 => HoleSelection.Front9,
-                _ => HoleSelection.Back9,
-            };
-        }
-
-        private static GameFormat PromptForFormat()
-        {
-            Console.WriteLine("Format: [1] Stroke play, [2] Stableford");
-            Console.Write("Selection: ");
-            return PromptForInt(value => value is 1 or 2) == 1 ? GameFormat.StrokePlay : GameFormat.Stableford;
-        }
-
-        private static int PromptForInt(Func<int, bool> validator)
-        {
-            while (true)
-            {
-                var input = Console.ReadLine();
-                if (int.TryParse(input, out var value) && validator(value))
-                {
-                    return value;
-                }
-
-                Console.Write("Invalid value, try again: ");
-            }
-        }
-
-        private static string PromptForNonEmpty()
-        {
-            while (true)
-            {
-                var input = Console.ReadLine();
-                if (!string.IsNullOrWhiteSpace(input))
-                {
-                    return input.Trim();
-                }
-
-                Console.Write("Value required: ");
-            }
-        }
-
-        private sealed class PlayerRound
-        {
-            private readonly List<HoleScore> stablefordResults = new();
-
-            public PlayerRound(string name, int handicapIndex, int effectiveHandicap, IReadOnlyList<int> strokesPerHole)
-            {
-                Name = name;
-                HandicapIndex = handicapIndex;
-                EffectiveHandicap = effectiveHandicap;
-                StrokesPerHole = strokesPerHole;
-            }
-
-            public string Name { get; }
-
-            public int HandicapIndex { get; }
-
-            public int EffectiveHandicap { get; }
-
-            public IReadOnlyList<int> StrokesPerHole { get; }
-
-            public int TotalStablefordPoints => stablefordResults.Sum(result => result.StablefordPoints);
-
-            public int TotalGrossStrokes { get; private set; }
-
-            public int NetStrokePlayScore { get; private set; }
-
-            public void AddStablefordResult(HoleScore score)
-            {
-                stablefordResults.Add(score);
-            }
-
-            public void AddStrokePlayResult(int gross, int strokesReceived)
-            {
-                TotalGrossStrokes += gross;
-                NetStrokePlayScore += gross - strokesReceived;
-            }
-        }
-    }
 }
+
+#pragma warning restore CA1303

--- a/src/FairwayQuest.Cli/src/Random/SeedRandomProvider.cs
+++ b/src/FairwayQuest.Cli/src/Random/SeedRandomProvider.cs
@@ -1,0 +1,44 @@
+namespace FairwayQuest.Cli.Random;
+
+using System.Diagnostics.CodeAnalysis;
+using FairwayQuest.Core.Abstractions;
+
+/// <summary>
+/// Deterministic <see cref="System.Random"/> wrapper implementing <see cref="IRandomProvider"/>.
+/// </summary>
+[SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Deterministic gameplay is required for reproducible rounds.")]
+internal sealed class SeedRandomProvider : IRandomProvider
+{
+    private readonly System.Random random;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SeedRandomProvider"/> class.
+    /// </summary>
+    /// <param name="seed">Optional deterministic seed.</param>
+    public SeedRandomProvider(int? seed)
+    {
+        this.random = seed.HasValue ? new System.Random(seed.Value) : new System.Random();
+    }
+
+    /// <inheritdoc />
+    public double NextDouble() => this.random.NextDouble();
+
+    /// <inheritdoc />
+    public double NextDouble(double minInclusive, double maxInclusive)
+    {
+        if (maxInclusive < minInclusive)
+        {
+            throw new ArgumentException("Max cannot be less than min.");
+        }
+
+        if (Math.Abs(maxInclusive - minInclusive) < double.Epsilon)
+        {
+            return minInclusive;
+        }
+
+        return minInclusive + ((maxInclusive - minInclusive) * this.random.NextDouble());
+    }
+
+    /// <inheritdoc />
+    public int NextInt(int minInclusive, int maxExclusive) => this.random.Next(minInclusive, maxExclusive);
+}

--- a/src/FairwayQuest.Cli/src/Round/ClubAdvisor.cs
+++ b/src/FairwayQuest.Cli/src/Round/ClubAdvisor.cs
@@ -1,0 +1,121 @@
+namespace FairwayQuest.Cli.Round;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FairwayQuest.Core.Shots;
+
+/// <summary>
+/// Provides heuristics for recommending clubs based on remaining yardage and lie.
+/// </summary>
+internal sealed class ClubAdvisor
+{
+    private readonly List<ClubDefinition> clubs;
+    private readonly List<ClubDefinition> fullSwingClubs;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClubAdvisor"/> class.
+    /// </summary>
+    public ClubAdvisor()
+    {
+        this.clubs = ShotEngine.GetSupportedClubs().ToList();
+        this.fullSwingClubs = this.clubs
+            .Where(club => !club.IsPutter)
+            .OrderBy(club => club.Average)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Suggests a club code based on the current context.
+    /// </summary>
+    /// <param name="lie">The current lie.</param>
+    /// <param name="remainingYards">The remaining distance to the pin.</param>
+    /// <param name="holePar">The par of the hole.</param>
+    /// <returns>The recommended club code.</returns>
+    public string Suggest(Lie lie, double remainingYards, int holePar)
+    {
+        if (lie == Lie.Green)
+        {
+            return "p";
+        }
+
+        var shortGame = ResolveShortGameSuggestion(lie, remainingYards);
+        if (shortGame is not null)
+        {
+            return shortGame;
+        }
+
+        if (ShouldUseDriver(lie, holePar, remainingYards))
+        {
+            return "d";
+        }
+
+        return this.SuggestFullSwingClub(lie, remainingYards);
+    }
+
+    /// <summary>
+    /// Retrieves the definition for a particular club code.
+    /// </summary>
+    /// <param name="code">The club code to lookup.</param>
+    /// <returns>The matching club definition.</returns>
+    public ClubDefinition GetDefinition(string code)
+    {
+        var match = this.clubs.FirstOrDefault(club => string.Equals(club.Code, code, StringComparison.OrdinalIgnoreCase));
+        return match ?? throw new InvalidOperationException($"Unknown club code '{code}'.");
+    }
+
+    /// <summary>
+    /// Enumerates all known clubs.
+    /// </summary>
+    /// <returns>The ordered collection of club definitions.</returns>
+    public IEnumerable<ClubDefinition> AllClubs() => this.clubs;
+
+    private static string? ResolveShortGameSuggestion(Lie lie, double remainingYards)
+    {
+        if (remainingYards <= 12)
+        {
+            return lie == Lie.Fringe ? "p" : "lw";
+        }
+
+        if (remainingYards <= 25)
+        {
+            return "sw";
+        }
+
+        if (remainingYards <= 40)
+        {
+            return "pw";
+        }
+
+        if (lie == Lie.Bunker)
+        {
+            return "sw";
+        }
+
+        return null;
+    }
+
+    private static bool ShouldUseDriver(Lie lie, int holePar, double remainingYards)
+    {
+        return lie == Lie.Tee && holePar >= 4 && remainingYards >= 220;
+    }
+
+    private string SuggestFullSwingClub(Lie lie, double remainingYards)
+    {
+        var adjustedTarget = remainingYards / GetLieMultiplier(lie);
+        var match = this.fullSwingClubs.FirstOrDefault(club => adjustedTarget <= club.Average + 8);
+        return match?.Code ?? this.fullSwingClubs[^1].Code;
+    }
+
+    private static double GetLieMultiplier(Lie lie)
+    {
+        return lie switch
+        {
+            Lie.Rough => 0.9,
+            Lie.DeepRough => 0.8,
+            Lie.Bunker => 0.85,
+            Lie.Fringe => 0.95,
+            _ => 1,
+        };
+    }
+}

--- a/src/FairwayQuest.Cli/src/Round/IShotSelector.cs
+++ b/src/FairwayQuest.Cli/src/Round/IShotSelector.cs
@@ -1,0 +1,19 @@
+namespace FairwayQuest.Cli.Round;
+
+using FairwayQuest.Core.Gameplay;
+using FairwayQuest.Core.Models;
+
+/// <summary>
+/// Abstraction for retrieving the club selection used during interactive play.
+/// </summary>
+public interface IShotSelector
+{
+    /// <summary>
+    /// Selects the club code to be used for the next shot.
+    /// </summary>
+    /// <param name="player">The player taking the shot.</param>
+    /// <param name="hole">The hole currently in play.</param>
+    /// <param name="state">The player's per-hole state.</param>
+    /// <returns>The club code to feed into the shot engine.</returns>
+    string SelectClub(Player player, Hole hole, PlayerHoleState state);
+}

--- a/src/FairwayQuest.Cli/src/Round/PlayerRoundTracker.cs
+++ b/src/FairwayQuest.Cli/src/Round/PlayerRoundTracker.cs
@@ -1,0 +1,68 @@
+namespace FairwayQuest.Cli.Round;
+
+using System.Collections.Generic;
+using System.Linq;
+using FairwayQuest.Core.Gameplay;
+
+/// <summary>
+/// Tracks per-hole results for a player throughout the round.
+/// </summary>
+internal sealed class PlayerRoundTracker
+{
+    private readonly List<int> grossPerHole = new();
+    private readonly List<int> netPerHole = new();
+    private readonly List<int> stablefordPerHole = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlayerRoundTracker"/> class.
+    /// </summary>
+    /// <param name="player">The player being tracked.</param>
+    public PlayerRoundTracker(Player player)
+    {
+        this.Player = player;
+    }
+
+    /// <summary>Gets the associated player.</summary>
+    public Player Player { get; }
+
+    /// <summary>Gets the recorded gross scores per hole.</summary>
+    public IReadOnlyList<int> GrossPerHole => this.grossPerHole;
+
+    /// <summary>Gets the recorded net scores per hole.</summary>
+    public IReadOnlyList<int> NetPerHole => this.netPerHole;
+
+    /// <summary>Gets the recorded Stableford points per hole.</summary>
+    public IReadOnlyList<int> StablefordPerHole => this.stablefordPerHole;
+
+    /// <summary>Gets the total gross strokes.</summary>
+    public int TotalGrossStrokes => this.grossPerHole.Sum();
+
+    /// <summary>Gets the total net strokes.</summary>
+    public int TotalNetStrokes => this.netPerHole.Sum();
+
+    /// <summary>Gets the total Stableford points.</summary>
+    public int TotalStablefordPoints => this.stablefordPerHole.Sum();
+
+    /// <summary>
+    /// Records a stroke play result for the current hole.
+    /// </summary>
+    /// <param name="gross">The gross strokes taken.</param>
+    /// <param name="net">The net strokes after allocations.</param>
+    public void RecordStrokePlay(int gross, int net)
+    {
+        this.grossPerHole.Add(gross);
+        this.netPerHole.Add(net);
+    }
+
+    /// <summary>
+    /// Records a Stableford result for the current hole.
+    /// </summary>
+    /// <param name="gross">The gross strokes taken.</param>
+    /// <param name="net">The net strokes after allocations.</param>
+    /// <param name="points">The Stableford points earned.</param>
+    public void RecordStableford(int gross, int net, int points)
+    {
+        this.RecordStrokePlay(gross, net);
+        this.stablefordPerHole.Add(points);
+    }
+}

--- a/src/FairwayQuest.Cli/src/Round/RoundRunner.cs
+++ b/src/FairwayQuest.Cli/src/Round/RoundRunner.cs
@@ -1,0 +1,206 @@
+namespace FairwayQuest.Cli.Round;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using FairwayQuest.Core.Abstractions;
+using FairwayQuest.Core.Gameplay;
+using FairwayQuest.Core.Models;
+using FairwayQuest.Core.Scoring;
+using FairwayQuest.Core.Shots;
+using GameplayRound = FairwayQuest.Core.Gameplay.Round;
+
+#pragma warning disable CA1303 // CLI intentionally writes literal strings to the console.
+
+/// <summary>
+/// Coordinates the shot-by-shot simulation for a configured round.
+/// </summary>
+internal sealed class RoundRunner
+{
+    private readonly GameplayRound round;
+    private readonly ShotEngine shotEngine;
+    private readonly IRandomProvider randomProvider;
+    private readonly AppOptions options;
+    private readonly ClubAdvisor advisor;
+    private readonly IShotSelector shotSelector;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RoundRunner"/> class.
+    /// </summary>
+    /// <param name="round">The configured round.</param>
+    /// <param name="shotEngine">The shot simulation engine.</param>
+    /// <param name="randomProvider">Deterministic random provider.</param>
+    /// <param name="options">Application options controlling narration.</param>
+    /// <param name="advisor">Optional advisor override.</param>
+    /// <param name="shotSelector">Optional shot selector override.</param>
+    public RoundRunner(
+        GameplayRound round,
+        ShotEngine shotEngine,
+        IRandomProvider randomProvider,
+        AppOptions options,
+        ClubAdvisor? advisor = null,
+        IShotSelector? shotSelector = null)
+    {
+        this.round = round;
+        this.shotEngine = shotEngine;
+        this.randomProvider = randomProvider;
+        this.options = options;
+        this.advisor = advisor ?? new ClubAdvisor();
+        this.shotSelector = shotSelector ?? new ShotPrompter(options, this.advisor);
+    }
+
+    /// <summary>
+    /// Plays the configured round to completion.
+    /// </summary>
+    /// <returns>Round trackers containing scoring aggregates.</returns>
+    public IReadOnlyList<PlayerRoundTracker> PlayRound()
+    {
+        var trackers = this.round.Players.Select(player => new PlayerRoundTracker(player)).ToList();
+        for (var holeIndex = 0; holeIndex < this.round.Holes.Count; holeIndex++)
+        {
+            this.PlayHole(holeIndex, trackers);
+        }
+
+        return trackers;
+    }
+
+    private void PlayHole(int holeIndex, List<PlayerRoundTracker> trackers)
+    {
+        var hole = this.round.Holes[holeIndex];
+        this.PrintHoleHeader(hole);
+        var holeState = this.CreateHoleState(hole);
+        this.RunHole(holeState);
+        this.SummarizeHole(holeIndex, holeState, trackers);
+    }
+
+    private HolePlayState CreateHoleState(Hole hole)
+    {
+        var states = this.round.Players.Select(player => new PlayerHoleState(this.ResolveYardage(hole, player))).ToList();
+        return new HolePlayState(hole, this.round.Players, states);
+    }
+
+    private void PrintHoleHeader(Hole hole)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"--- Hole {hole.Number} | Par {hole.Par} ---");
+    }
+
+    private double ResolveYardage(Hole hole, Player player)
+    {
+        if (!hole.Yards.TryGetValue(player.Tee, out var yardage))
+        {
+            throw new InvalidOperationException($"Tee '{player.Tee}' missing for hole {hole.Number}.");
+        }
+
+        return yardage;
+    }
+
+    private void RunHole(HolePlayState holeState)
+    {
+        while (!holeState.IsComplete)
+        {
+            this.ExecuteRotation(holeState);
+        }
+    }
+
+    private void ExecuteRotation(HolePlayState holeState)
+    {
+        for (var playerIndex = 0; playerIndex < this.round.Players.Count; playerIndex++)
+        {
+            this.ProcessTurn(holeState, playerIndex);
+        }
+    }
+
+    private void ProcessTurn(HolePlayState holeState, int playerIndex)
+    {
+        var state = holeState.PlayerStates[playerIndex];
+        if (state.IsHoled)
+        {
+            return;
+        }
+
+        this.TakeShot(holeState, playerIndex);
+    }
+
+    private void TakeShot(HolePlayState holeState, int playerIndex)
+    {
+        var player = this.round.Players[playerIndex];
+        var state = holeState.PlayerStates[playerIndex];
+        var club = this.shotSelector.SelectClub(player, holeState.Hole, state);
+        var request = new ShotRequest(state.Lie, state.RemainingYards, club);
+        var result = this.shotEngine.Execute(request, this.randomProvider);
+        state.ApplyShot(result);
+        Console.WriteLine(result.Commentary);
+        if (!this.options.FastMode)
+        {
+            Console.WriteLine();
+        }
+    }
+
+    private void SummarizeHole(int holeIndex, HolePlayState holeState, List<PlayerRoundTracker> trackers)
+    {
+        Console.WriteLine($"Hole {holeState.Hole.Number} summary:");
+        for (var playerIndex = 0; playerIndex < this.round.Players.Count; playerIndex++)
+        {
+            this.SummarizePlayerHole(holeIndex, holeState, trackers, playerIndex);
+        }
+    }
+
+    private void SummarizePlayerHole(int holeIndex, HolePlayState holeState, List<PlayerRoundTracker> trackers, int playerIndex)
+    {
+        var player = this.round.Players[playerIndex];
+        var state = holeState.PlayerStates[playerIndex];
+        var strokesReceived = player.AllocatedStrokesPerHole[holeIndex];
+        var gross = state.GrossStrokes;
+
+        if (this.round.Format == GameFormat.Stableford)
+        {
+            this.SummarizeStableford(holeState, trackers, playerIndex, player, strokesReceived, gross);
+            return;
+        }
+
+        this.SummarizeStrokePlay(trackers, playerIndex, player, strokesReceived, gross, holeState.Hole.Par);
+    }
+
+    private void SummarizeStableford(
+        HolePlayState holeState,
+        List<PlayerRoundTracker> trackers,
+        int playerIndex,
+        Player player,
+        int strokesReceived,
+        int gross)
+    {
+        var score = ScoreCalculator.CalculateStableford(holeState.Hole.Par, gross, strokesReceived);
+        trackers[playerIndex].RecordStableford(score.GrossStrokes, score.NetStrokes, score.StablefordPoints);
+        Console.WriteLine(
+            $" {player.Name}: Gross {gross}, Net {score.NetStrokes} ({this.DescribeRelative(score.NetStrokes - holeState.Hole.Par)}) → {score.StablefordPoints} pts");
+    }
+
+    private void SummarizeStrokePlay(
+        List<PlayerRoundTracker> trackers,
+        int playerIndex,
+        Player player,
+        int strokesReceived,
+        int gross,
+        int par)
+    {
+        var net = gross - strokesReceived;
+        trackers[playerIndex].RecordStrokePlay(gross, net);
+        Console.WriteLine($" {player.Name}: Gross {gross}, Net {net} ({this.DescribeRelative(net - par)})");
+    }
+    }
+
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Instance method keeps symmetry with other helpers.")]
+    private string DescribeRelative(int relative)
+    {
+        return relative switch
+        {
+            < 0 => $"{Math.Abs(relative)} under",
+            0 => "even",
+            _ => $"{relative} over",
+        };
+    }
+}
+
+#pragma warning restore CA1303

--- a/src/FairwayQuest.Cli/src/Round/ShotPrompter.cs
+++ b/src/FairwayQuest.Cli/src/Round/ShotPrompter.cs
@@ -1,0 +1,179 @@
+namespace FairwayQuest.Cli.Round;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using FairwayQuest.Core.Gameplay;
+using FairwayQuest.Core.Models;
+using FairwayQuest.Core.Shots;
+
+#pragma warning disable CA1303 // CLI intentionally writes literal strings to the console.
+
+/// <summary>
+/// Interactive implementation of <see cref="IShotSelector"/> prompting the user for club choices.
+/// </summary>
+internal sealed class ShotPrompter : IShotSelector
+{
+    private readonly AppOptions options;
+    private readonly ClubAdvisor advisor;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ShotPrompter"/> class.
+    /// </summary>
+    /// <param name="options">Application options controlling automation.</param>
+    /// <param name="advisor">Advisor used for auto-suggesting clubs.</param>
+    public ShotPrompter(AppOptions options, ClubAdvisor advisor)
+    {
+        this.options = options;
+        this.advisor = advisor;
+    }
+
+    /// <inheritdoc />
+    public string SelectClub(Player player, Hole hole, PlayerHoleState state)
+    {
+        var suggestion = this.advisor.Suggest(state.Lie, state.RemainingYards, hole.Par);
+        return this.options.AutoPlay
+            ? this.HandleAutoPlay(player, hole, state, suggestion)
+            : this.PromptForClub(player, hole, state, suggestion);
+    }
+
+    private string HandleAutoPlay(Player player, Hole hole, PlayerHoleState state, string suggestion)
+    {
+        Console.WriteLine(this.FormatHeader(player, hole, state));
+        Console.WriteLine($"Auto selects {this.advisor.GetDefinition(suggestion).Label}");
+        return suggestion;
+    }
+
+    private string PromptForClub(Player player, Hole hole, PlayerHoleState state, string suggestion)
+    {
+        while (true)
+        {
+            this.DisplayPrompt(player, hole, state, suggestion);
+            var input = Console.ReadLine();
+            var selection = this.ProcessInput(input, state, suggestion);
+            if (!string.IsNullOrEmpty(selection))
+            {
+                return selection;
+            }
+        }
+    }
+
+    private void DisplayPrompt(Player player, Hole hole, PlayerHoleState state, string suggestion)
+    {
+        Console.WriteLine(this.FormatHeader(player, hole, state));
+        Console.Write($"Select club (? for list, 'auto' for {suggestion}, 'list' for shots, 'quit' to exit): ");
+    }
+
+    private string? ProcessInput(string? input, PlayerHoleState state, string suggestion)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return null;
+        }
+
+        var trimmed = input.Trim();
+        if (this.TryResolveCommand(trimmed, state, suggestion, out var commandResult))
+        {
+            return commandResult;
+        }
+
+        if (this.TryNormalizeClub(trimmed, state, out var normalizedClub))
+        {
+            return normalizedClub;
+        }
+
+        Console.WriteLine("Unknown club. Enter '?' for options.");
+        return null;
+    }
+
+    private bool TryResolveCommand(string input, PlayerHoleState state, string suggestion, out string? resolved)
+    {
+        resolved = null;
+        if (string.Equals(input, "?", StringComparison.OrdinalIgnoreCase))
+        {
+            this.PrintHelp();
+            return true;
+        }
+
+        if (string.Equals(input, "auto", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine($"Using suggested {this.advisor.GetDefinition(suggestion).Label}");
+            resolved = suggestion;
+            return true;
+        }
+
+        if (string.Equals(input, "list", StringComparison.OrdinalIgnoreCase))
+        {
+            this.PrintShotHistory(state);
+            return true;
+        }
+
+        if (string.Equals(input, "quit", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new OperationCanceledException();
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Displays the available clubs and commands.
+    /// </summary>
+    private void PrintHelp()
+    {
+        Console.WriteLine("Available clubs:");
+        foreach (var club in this.advisor.AllClubs())
+        {
+            Console.WriteLine(club.IsPutter ? $" - {club.Label}: putter" : $" - {club.Label}: {club.Min:0}-{club.Max:0}y");
+        }
+
+        Console.WriteLine("Commands: ?, auto, list, quit");
+    }
+
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Maintained as instance for potential option-aware output.")]
+    private void PrintShotHistory(PlayerHoleState state)
+    {
+        if (state.Commentary.Count == 0)
+        {
+            Console.WriteLine("No shots yet.");
+            return;
+        }
+
+        Console.WriteLine("Shot history:");
+        for (var i = 0; i < state.Commentary.Count; i++)
+        {
+            Console.WriteLine($" {i + 1}. {state.Commentary[i]}");
+        }
+    }
+
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Uses instance context for future customization.")]
+    private string FormatHeader(Player player, Hole hole, PlayerHoleState state)
+    {
+        return $"[{player.Name}] H{hole.Number} | Par {hole.Par} | Yardage {hole.Yards[player.Tee]}y ({player.Tee} tee) | Rem {state.RemainingYards:0}y | Lie {state.Lie}";
+    }
+
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Retained as instance to share advisor context if required.")]
+    private bool TryNormalizeClub(string clubCode, PlayerHoleState state, out string normalized)
+    {
+        normalized = string.Empty;
+
+        if (state.Lie == Lie.Green && !string.Equals(clubCode, "p", StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine("On the green you must use the putter.");
+            return false;
+        }
+
+        var match = ShotEngine
+            .GetSupportedClubs()
+            .FirstOrDefault(club => string.Equals(club.Code, clubCode, StringComparison.OrdinalIgnoreCase));
+        if (match is null)
+        {
+            return false;
+        }
+
+        normalized = match.Code;
+        return true;
+    }
+}
+
+#pragma warning restore CA1303

--- a/src/FairwayQuest.Core/src/Abstractions/IRandomProvider.cs
+++ b/src/FairwayQuest.Core/src/Abstractions/IRandomProvider.cs
@@ -1,0 +1,29 @@
+namespace FairwayQuest.Core.Abstractions;
+
+/// <summary>
+/// Provides deterministic random values for the shot engine and simulations.
+/// </summary>
+public interface IRandomProvider
+{
+    /// <summary>
+    /// Gets the next double in the interval [0, 1).
+    /// </summary>
+    /// <returns>The sampled value.</returns>
+    double NextDouble();
+
+    /// <summary>
+    /// Gets the next double constrained to the provided range.
+    /// </summary>
+    /// <param name="minInclusive">The inclusive lower bound.</param>
+    /// <param name="maxInclusive">The inclusive upper bound.</param>
+    /// <returns>The sampled value within the range.</returns>
+    double NextDouble(double minInclusive, double maxInclusive);
+
+    /// <summary>
+    /// Gets the next integer within the specified range.
+    /// </summary>
+    /// <param name="minInclusive">The inclusive lower bound.</param>
+    /// <param name="maxExclusive">The exclusive upper bound.</param>
+    /// <returns>The sampled integer.</returns>
+    int NextInt(int minInclusive, int maxExclusive);
+}

--- a/src/FairwayQuest.Core/src/Gameplay/HolePlayState.cs
+++ b/src/FairwayQuest.Core/src/Gameplay/HolePlayState.cs
@@ -1,0 +1,53 @@
+namespace FairwayQuest.Core.Gameplay;
+
+using System.Linq;
+using FairwayQuest.Core.Models;
+using FairwayQuest.Core.Shots;
+
+/// <summary>
+/// Represents the live play state for a single hole across all players.
+/// </summary>
+public sealed class HolePlayState
+{
+    private readonly IReadOnlyList<PlayerHoleState> playerStates;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HolePlayState"/> class.
+    /// </summary>
+    /// <param name="hole">The hole being played.</param>
+    /// <param name="players">The players in turn order.</param>
+    /// <param name="playerStates">The per-player state collection.</param>
+    public HolePlayState(Hole hole, IReadOnlyList<Player> players, IReadOnlyList<PlayerHoleState> playerStates)
+    {
+        ArgumentNullException.ThrowIfNull(hole);
+        ArgumentNullException.ThrowIfNull(players);
+        ArgumentNullException.ThrowIfNull(playerStates);
+
+        if (players.Count != playerStates.Count)
+        {
+            throw new ArgumentException("Players and states must align in length.");
+        }
+
+        this.Hole = hole;
+        this.playerStates = playerStates;
+    }
+
+    /// <summary>Gets the hole being played.</summary>
+    public Hole Hole { get; }
+
+    /// <summary>Gets the per-player state collection.</summary>
+    public IReadOnlyList<PlayerHoleState> PlayerStates => this.playerStates;
+
+    /// <summary>Gets a value indicating whether all players have holed out.</summary>
+    public bool IsComplete => this.playerStates.All(state => state.IsHoled);
+
+    /// <summary>
+    /// Retrieves the state for a specific player index.
+    /// </summary>
+    /// <param name="playerIndex">The zero-based player index.</param>
+    /// <returns>The corresponding player state.</returns>
+    public PlayerHoleState GetStateForPlayer(int playerIndex)
+    {
+        return this.playerStates[playerIndex];
+    }
+}

--- a/src/FairwayQuest.Core/src/Gameplay/Player.cs
+++ b/src/FairwayQuest.Core/src/Gameplay/Player.cs
@@ -1,0 +1,48 @@
+namespace FairwayQuest.Core.Gameplay;
+
+/// <summary>
+/// Represents a player participating in a round.
+/// </summary>
+public sealed class Player
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Player"/> class.
+    /// </summary>
+    /// <param name="name">The player name.</param>
+    /// <param name="handicapIndex18">The 18-hole handicap index.</param>
+    /// <param name="tee">The selected tee identifier.</param>
+    /// <param name="effectivePlayingHandicap">The effective playing handicap for the round.</param>
+    /// <param name="allocatedStrokesPerHole">The allocated strokes per hole.</param>
+    public Player(
+        string name,
+        int handicapIndex18,
+        string tee,
+        int effectivePlayingHandicap,
+        IReadOnlyList<int> allocatedStrokesPerHole)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tee);
+        ArgumentNullException.ThrowIfNull(allocatedStrokesPerHole);
+
+        this.Name = name;
+        this.HandicapIndex18 = handicapIndex18;
+        this.Tee = tee;
+        this.EffectivePlayingHandicap = effectivePlayingHandicap;
+        this.AllocatedStrokesPerHole = allocatedStrokesPerHole;
+    }
+
+    /// <summary>Gets the player name.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the eighteen-hole handicap index.</summary>
+    public int HandicapIndex18 { get; }
+
+    /// <summary>Gets the selected tee identifier.</summary>
+    public string Tee { get; }
+
+    /// <summary>Gets the effective playing handicap for the round.</summary>
+    public int EffectivePlayingHandicap { get; }
+
+    /// <summary>Gets the per-hole stroke allocations.</summary>
+    public IReadOnlyList<int> AllocatedStrokesPerHole { get; }
+}

--- a/src/FairwayQuest.Core/src/Gameplay/PlayerHoleState.cs
+++ b/src/FairwayQuest.Core/src/Gameplay/PlayerHoleState.cs
@@ -1,0 +1,62 @@
+namespace FairwayQuest.Core.Gameplay;
+
+using FairwayQuest.Core.Shots;
+
+/// <summary>
+/// Tracks per-hole progress for a player.
+/// </summary>
+public sealed class PlayerHoleState
+{
+    private readonly List<string> commentaryLog = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlayerHoleState"/> class.
+    /// </summary>
+    /// <param name="startingYards">The starting yardage from the tee.</param>
+    public PlayerHoleState(double startingYards)
+    {
+        if (startingYards <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(startingYards), startingYards, "Starting yardage must be positive.");
+        }
+
+        this.RemainingYards = startingYards;
+        this.Lie = Lie.Tee;
+    }
+
+    /// <summary>Gets the remaining yardage to the pin.</summary>
+    public double RemainingYards { get; private set; }
+
+    /// <summary>Gets the current lie.</summary>
+    public Lie Lie { get; private set; }
+
+    /// <summary>Gets the number of strokes taken on the hole.</summary>
+    public int StrokeCount { get; private set; }
+
+    /// <summary>Gets the accumulated penalty strokes.</summary>
+    public int PenaltyStrokes { get; private set; }
+
+    /// <summary>Gets a value indicating whether the player has holed out.</summary>
+    public bool IsHoled { get; private set; }
+
+    /// <summary>Gets the commentary lines produced for each shot.</summary>
+    public IReadOnlyList<string> Commentary => this.commentaryLog;
+
+    /// <summary>Gets the gross strokes including penalties.</summary>
+    public int GrossStrokes => this.StrokeCount + this.PenaltyStrokes;
+
+    /// <summary>
+    /// Applies a simulated shot result to the current state.
+    /// </summary>
+    /// <param name="result">The shot result to apply.</param>
+    public void ApplyShot(ShotResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        this.StrokeCount += result.StrokeIncrement;
+        this.PenaltyStrokes += result.PenaltyStrokes;
+        this.RemainingYards = result.NewRemaining;
+        this.Lie = result.NewLie;
+        this.IsHoled = result.Holed;
+        this.commentaryLog.Add(result.Commentary);
+    }
+}

--- a/src/FairwayQuest.Core/src/Gameplay/Round.cs
+++ b/src/FairwayQuest.Core/src/Gameplay/Round.cs
@@ -1,0 +1,45 @@
+namespace FairwayQuest.Core.Gameplay;
+
+using FairwayQuest.Core.Models;
+
+/// <summary>
+/// Represents a configured round of golf with associated players and format.
+/// </summary>
+public sealed class Round
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Round"/> class.
+    /// </summary>
+    /// <param name="course">The course being played.</param>
+    /// <param name="holes">The ordered set of holes.</param>
+    /// <param name="players">The participating players.</param>
+    /// <param name="format">The scoring format.</param>
+    public Round(Course course, IReadOnlyList<Hole> holes, IReadOnlyList<Player> players, GameFormat format)
+    {
+        ArgumentNullException.ThrowIfNull(course);
+        ArgumentNullException.ThrowIfNull(holes);
+        ArgumentNullException.ThrowIfNull(players);
+
+        if (players.Count == 0)
+        {
+            throw new ArgumentException("Rounds require at least one player.", nameof(players));
+        }
+
+        this.Course = course;
+        this.Holes = holes;
+        this.Players = players;
+        this.Format = format;
+    }
+
+    /// <summary>Gets the course being played.</summary>
+    public Course Course { get; }
+
+    /// <summary>Gets the holes included in the round.</summary>
+    public IReadOnlyList<Hole> Holes { get; }
+
+    /// <summary>Gets the participating players.</summary>
+    public IReadOnlyList<Player> Players { get; }
+
+    /// <summary>Gets the scoring format for the round.</summary>
+    public GameFormat Format { get; }
+}

--- a/src/FairwayQuest.Core/src/Shots/ClubCategory.cs
+++ b/src/FairwayQuest.Core/src/Shots/ClubCategory.cs
@@ -1,0 +1,19 @@
+namespace FairwayQuest.Core.Shots;
+
+/// <summary>
+/// Categorizes clubs by their general type.
+/// </summary>
+public enum ClubCategory
+{
+    /// <summary>Wood or driver-style club.</summary>
+    Wood,
+
+    /// <summary>Iron.</summary>
+    Iron,
+
+    /// <summary>Wedge.</summary>
+    Wedge,
+
+    /// <summary>Putter.</summary>
+    Putter,
+}

--- a/src/FairwayQuest.Core/src/Shots/ClubDefinition.cs
+++ b/src/FairwayQuest.Core/src/Shots/ClubDefinition.cs
@@ -1,0 +1,22 @@
+namespace FairwayQuest.Core.Shots;
+
+/// <summary>
+/// Provides metadata about a golf club.
+/// </summary>
+public sealed record ClubDefinition(string Code, string Label, double Min, double Max, ClubCategory Category, int DisplayOrder)
+{
+    /// <summary>Gets the average carry distance for the club.</summary>
+    public double Average => (this.Min + this.Max) / 2d;
+
+    /// <summary>Gets a value indicating whether the club is a putter.</summary>
+    public bool IsPutter => this.Category == ClubCategory.Putter;
+
+    /// <summary>Gets a value indicating whether the club is a wedge.</summary>
+    public bool IsWedge => this.Category == ClubCategory.Wedge;
+
+    /// <summary>Gets a value indicating whether the club is an iron.</summary>
+    public bool IsIron => this.Category == ClubCategory.Iron;
+
+    /// <summary>Gets a value indicating whether the club can realistically hole out from the fairway.</summary>
+    public bool CanHoleOut => this.Category is ClubCategory.Iron or ClubCategory.Wedge;
+}

--- a/src/FairwayQuest.Core/src/Shots/Lie.cs
+++ b/src/FairwayQuest.Core/src/Shots/Lie.cs
@@ -1,0 +1,28 @@
+namespace FairwayQuest.Core.Shots;
+
+/// <summary>
+/// Represents the current lie of the golf ball.
+/// </summary>
+public enum Lie
+{
+    /// <summary>Ball is on the tee box.</summary>
+    Tee,
+
+    /// <summary>Ball rests on the fairway.</summary>
+    Fairway,
+
+    /// <summary>Ball lies in light rough.</summary>
+    Rough,
+
+    /// <summary>Ball lies in heavy rough.</summary>
+    DeepRough,
+
+    /// <summary>Ball is in a bunker.</summary>
+    Bunker,
+
+    /// <summary>Ball rests on the fringe.</summary>
+    Fringe,
+
+    /// <summary>Ball is on the putting green.</summary>
+    Green,
+}

--- a/src/FairwayQuest.Core/src/Shots/ShotEngine.cs
+++ b/src/FairwayQuest.Core/src/Shots/ShotEngine.cs
@@ -1,0 +1,344 @@
+namespace FairwayQuest.Core.Shots;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using FairwayQuest.Core.Abstractions;
+
+/// <summary>
+/// Simulates golf shots using simplified physics and probabilistic outcomes.
+/// </summary>
+public sealed class ShotEngine
+{
+    private const double HoleOutProximity = 3d;
+    private const double HoleOutProbability = 0.01d;
+    private const double MishitProbability = 0.07d;
+    private const double DuffProbability = 0.02d;
+    private const double PenaltyProbability = 0.015d;
+
+    private static readonly Dictionary<string, ClubDefinition> Clubs = BuildClubMap();
+
+    private static readonly Dictionary<Lie, double> LieDistanceModifiers = new Dictionary<Lie, double>
+    {
+        [Lie.Tee] = 0d,
+        [Lie.Fairway] = 0d,
+        [Lie.Rough] = -0.10d,
+        [Lie.DeepRough] = -0.20d,
+        [Lie.Bunker] = -0.15d,
+        [Lie.Fringe] = -0.05d,
+        [Lie.Green] = 0d,
+    };
+
+    /// <summary>
+    /// Returns the metadata describing the supported clubs.
+    /// </summary>
+    /// <returns>An ordered list of club definitions.</returns>
+    public static IReadOnlyList<ClubDefinition> GetSupportedClubs() => Clubs.Values.OrderBy(c => c.DisplayOrder).ToList();
+
+    /// <summary>
+    /// Executes a shot simulation for the provided context.
+    /// </summary>
+    /// <param name="request">The shot request describing the current lie and club.</param>
+    /// <param name="random">The random provider supplying deterministic values.</param>
+    /// <returns>The resulting shot outcome.</returns>
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Instance usage simplifies DI patterns.")]
+    public ShotResult Execute(ShotRequest request, IRandomProvider random)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(random);
+
+        var club = ResolveClub(request.Club);
+        return club.IsPutter
+            ? ResolvePuttingShot(request, random, club)
+            : ResolveFullSwingShot(request, random, club);
+    }
+
+    private static ClubDefinition ResolveClub(string code)
+    {
+        var key = code.Trim();
+        if (!Clubs.TryGetValue(key, out var definition))
+        {
+            throw new ArgumentException($"Unsupported club '{code}'.", nameof(code));
+        }
+
+        return definition;
+    }
+
+    private ShotResult ResolveFullSwingShot(ShotRequest request, IRandomProvider random, ClubDefinition club)
+    {
+        if (IsPenalty(random))
+        {
+            return CreatePenaltyResult(request, club);
+        }
+
+        var distance = CalculateTravelDistance(request, random, club, out var contactLabel);
+        var remaining = CalculateRemaining(request.RemainingYards, distance);
+        var lateral = ResolveLateral(random);
+        var holed = DetermineHoleOut(random, club, distance, request.RemainingYards);
+        var newLie = holed ? Lie.Green : DetermineLandingLie(club, remaining, random);
+        var commentary = BuildCommentary(club, distance, lateral, newLie, remaining, contactLabel, holed, false);
+
+        return new ShotResult(1, 0, distance, lateral, newLie, remaining, holed, commentary);
+    }
+
+    private static bool IsPenalty(IRandomProvider random) => random.NextDouble() < PenaltyProbability;
+
+    private static ShotResult CreatePenaltyResult(ShotRequest request, ClubDefinition club)
+    {
+        var commentary = $"{club.Label} → OB (penalty +1); {request.RemainingYards:0}y remaining";
+        return new ShotResult(1, 1, 0, "penalty", Lie.Rough, request.RemainingYards, false, commentary);
+    }
+
+    private static ShotResult ResolvePuttingShot(ShotRequest request, IRandomProvider random, ClubDefinition club)
+    {
+        var putts = ResolvePuttCount(request.RemainingYards, random);
+        var commentary = putts switch
+        {
+            1 => "p → holed",  // short, direct message
+            _ => $"p → holed ({putts} putts)",
+        };
+
+        return new ShotResult(putts, 0, request.RemainingYards, "straight", Lie.Green, 0, true, commentary);
+    }
+
+    private static int ResolvePuttCount(double remaining, IRandomProvider random)
+    {
+        var roll = random.NextDouble();
+        if (remaining <= 2)
+        {
+            return roll < 0.8 ? 1 : roll < 0.95 ? 2 : 3;
+        }
+
+        if (remaining <= 8)
+        {
+            return roll < 0.55 ? 1 : 2;
+        }
+
+        return roll < 0.7 ? 2 : 3;
+    }
+
+    private double CalculateTravelDistance(ShotRequest request, IRandomProvider random, ClubDefinition club, out string contactLabel)
+    {
+        var baseDistance = SampleClubDistance(club, random);
+        var lieAdjusted = ApplyLieModifier(baseDistance, request.Lie);
+        var contactAdjusted = ApplyContactVariance(lieAdjusted, random, out contactLabel);
+        var clamped = Math.Max(0, contactAdjusted);
+        return LimitOvershoot(clamped, request.RemainingYards);
+    }
+
+    private static double SampleClubDistance(ClubDefinition club, IRandomProvider random)
+    {
+        var span = club.Max - club.Min;
+        var distance = club.Min + (span * random.NextDouble());
+        return (distance + (club.Average * 0.4)) / 1.4;
+    }
+
+    private static double ApplyLieModifier(double distance, Lie lie)
+    {
+        return distance * (1 + LieDistanceModifiers[lie]);
+    }
+
+    private static double ApplyContactVariance(double distance, IRandomProvider random, out string contactLabel)
+    {
+        var roll = random.NextDouble();
+        if (roll < DuffProbability)
+        {
+            return ResolveDuff(distance, random, out contactLabel);
+        }
+
+        if (roll < DuffProbability + MishitProbability)
+        {
+            return ResolveMishit(distance, random, out contactLabel);
+        }
+
+        return ResolvePureContact(distance, random, out contactLabel);
+    }
+
+    private static double ResolveDuff(double distance, IRandomProvider random, out string contactLabel)
+    {
+        contactLabel = "duffed";
+        return distance * random.NextDouble(0.05, 0.2);
+    }
+
+    private static double ResolveMishit(double distance, IRandomProvider random, out string contactLabel)
+    {
+        contactLabel = "mishit";
+        return distance * random.NextDouble(0.35, 0.6);
+    }
+
+    private static double ResolvePureContact(double distance, IRandomProvider random, out string contactLabel)
+    {
+        contactLabel = "pure";
+        return distance * random.NextDouble(0.9, 1.05);
+    }
+
+    private static double LimitOvershoot(double distance, double remaining)
+    {
+        return Math.Min(distance, remaining + 30);
+    }
+
+    private static double CalculateRemaining(double starting, double travelled)
+    {
+        return Math.Max(0, starting - travelled);
+    }
+
+    private static string ResolveLateral(IRandomProvider random)
+    {
+        var roll = random.NextDouble();
+        return roll switch
+        {
+            < 0.65 => "straight",
+            < 0.8 => random.NextDouble() < 0.5 ? "pull" : "push",
+            < 0.92 => random.NextDouble() < 0.5 ? "draw" : "fade",
+            < 0.97 => random.NextDouble() < 0.5 ? "hook" : "slice",
+            _ => "straight",
+        };
+    }
+
+    private static bool DetermineHoleOut(IRandomProvider random, ClubDefinition club, double distance, double remaining)
+    {
+        if (remaining > HoleOutProximity + 5)
+        {
+            return false;
+        }
+
+        if (!club.CanHoleOut)
+        {
+            return false;
+        }
+
+        if (Math.Abs(distance - remaining) > HoleOutProximity)
+        {
+            return false;
+        }
+
+        return random.NextDouble() < HoleOutProbability;
+    }
+
+    private static Lie DetermineLandingLie(ClubDefinition club, double remaining, IRandomProvider random)
+    {
+        if (remaining <= 2)
+        {
+            return Lie.Green;
+        }
+
+        if (remaining <= 8)
+        {
+            return ResolveNearGreenLanding(random);
+        }
+
+        if (remaining <= 30)
+        {
+            return ResolveApproachLanding(random, club);
+        }
+
+        return ResolveLongLanding(random, club);
+    }
+
+    private static Lie ResolveNearGreenLanding(IRandomProvider random)
+    {
+        return random.NextDouble() < 0.7 ? Lie.Green : Lie.Fringe;
+    }
+
+    private static Lie ResolveApproachLanding(IRandomProvider random, ClubDefinition club)
+    {
+        var wedgeBias = club.IsWedge ? 0.5 : 0.3;
+        var roll = random.NextDouble();
+        if (roll < wedgeBias)
+        {
+            return Lie.Fringe;
+        }
+
+        if (roll < wedgeBias + 0.3)
+        {
+            return Lie.Green;
+        }
+
+        return random.NextDouble() < 0.5 ? Lie.Fairway : Lie.Rough;
+    }
+
+    private static Lie ResolveLongLanding(IRandomProvider random, ClubDefinition club)
+    {
+        var roll = random.NextDouble();
+        if (roll < 0.6)
+        {
+            return Lie.Fairway;
+        }
+
+        if (roll < 0.82)
+        {
+            return Lie.Rough;
+        }
+
+        if (roll < 0.92)
+        {
+            return Lie.DeepRough;
+        }
+
+        return club.IsWedge || club.IsIron ? Lie.Fringe : Lie.Bunker;
+    }
+
+    private static string BuildCommentary(
+        ClubDefinition club,
+        double distance,
+        string lateral,
+        Lie newLie,
+        double remaining,
+        string contact,
+        bool holed,
+        bool penalty)
+    {
+        if (penalty)
+        {
+            return BuildPenaltyCommentary(club, remaining);
+        }
+
+        if (holed)
+        {
+            return BuildHoledCommentary(club);
+        }
+
+        return BuildStandardCommentary(club, distance, lateral, newLie, remaining, contact);
+    }
+
+    private static string BuildPenaltyCommentary(ClubDefinition club, double remaining)
+    {
+        return $"{club.Label} → penalty; {remaining:0}y remaining";
+    }
+
+    private static string BuildHoledCommentary(ClubDefinition club)
+    {
+        return club.IsPutter ? "p → holed" : $"{club.Label} → holed!";
+    }
+
+    private static string BuildStandardCommentary(ClubDefinition club, double distance, string lateral, Lie newLie, double remaining, string contact)
+    {
+        var contactText = contact == "pure" ? string.Empty : $"{contact} ";
+        var message = $"{club.Label} → {contactText}{distance:0}y, {lateral}, {newLie}, {remaining:0}y to pin";
+        return message.Replace("  ", " ", StringComparison.Ordinal);
+    }
+
+    private static Dictionary<string, ClubDefinition> BuildClubMap()
+    {
+        var clubs = new[]
+        {
+            new ClubDefinition("d", "D", 230, 280, ClubCategory.Wood, 1),
+            new ClubDefinition("3w", "3W", 210, 240, ClubCategory.Wood, 2),
+            new ClubDefinition("5w", "5W", 195, 215, ClubCategory.Wood, 3),
+            new ClubDefinition("3i", "3i", 180, 200, ClubCategory.Iron, 4),
+            new ClubDefinition("4i", "4i", 170, 190, ClubCategory.Iron, 5),
+            new ClubDefinition("5i", "5i", 160, 180, ClubCategory.Iron, 6),
+            new ClubDefinition("6i", "6i", 150, 170, ClubCategory.Iron, 7),
+            new ClubDefinition("7i", "7i", 140, 160, ClubCategory.Iron, 8),
+            new ClubDefinition("8i", "8i", 130, 150, ClubCategory.Iron, 9),
+            new ClubDefinition("9i", "9i", 120, 140, ClubCategory.Iron, 10),
+            new ClubDefinition("pw", "PW", 95, 115, ClubCategory.Wedge, 11),
+            new ClubDefinition("sw", "SW", 70, 95, ClubCategory.Wedge, 12),
+            new ClubDefinition("lw", "LW", 40, 70, ClubCategory.Wedge, 13),
+            new ClubDefinition("p", "p", 0, 0, ClubCategory.Putter, 14),
+        };
+
+        return clubs.ToDictionary(club => club.Code, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/FairwayQuest.Core/src/Shots/ShotRequest.cs
+++ b/src/FairwayQuest.Core/src/Shots/ShotRequest.cs
@@ -1,0 +1,42 @@
+namespace FairwayQuest.Core.Shots;
+
+/// <summary>
+/// Defines the information required to simulate a golf shot.
+/// </summary>
+public sealed class ShotRequest
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ShotRequest"/> class.
+    /// </summary>
+    /// <param name="lie">The current lie.</param>
+    /// <param name="remainingYards">The remaining distance to the pin in yards.</param>
+    /// <param name="club">The club code being used.</param>
+    public ShotRequest(Lie lie, double remainingYards, string club)
+    {
+        if (remainingYards < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(remainingYards), remainingYards, "Remaining distance cannot be negative.");
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(club);
+
+        this.Lie = lie;
+        this.RemainingYards = remainingYards;
+        this.Club = club.Trim();
+    }
+
+    /// <summary>
+    /// Gets the current lie.
+    /// </summary>
+    public Lie Lie { get; }
+
+    /// <summary>
+    /// Gets the remaining distance in yards.
+    /// </summary>
+    public double RemainingYards { get; }
+
+    /// <summary>
+    /// Gets the selected club code.
+    /// </summary>
+    public string Club { get; }
+}

--- a/src/FairwayQuest.Core/src/Shots/ShotResult.cs
+++ b/src/FairwayQuest.Core/src/Shots/ShotResult.cs
@@ -1,0 +1,72 @@
+namespace FairwayQuest.Core.Shots;
+
+/// <summary>
+/// Represents the outcome of a simulated golf shot.
+/// </summary>
+public sealed class ShotResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ShotResult"/> class.
+    /// </summary>
+    /// <param name="strokeIncrement">The stroke increment added by the shot.</param>
+    /// <param name="penaltyStrokes">The penalty strokes incurred.</param>
+    /// <param name="distance">The distance travelled.</param>
+    /// <param name="lateral">The lateral descriptor.</param>
+    /// <param name="newLie">The resulting lie.</param>
+    /// <param name="newRemaining">The new remaining yardage.</param>
+    /// <param name="holed">Whether the ball was holed.</param>
+    /// <param name="commentary">The commentary describing the shot.</param>
+    public ShotResult(
+        int strokeIncrement,
+        int penaltyStrokes,
+        double distance,
+        string lateral,
+        Lie newLie,
+        double newRemaining,
+        bool holed,
+        string commentary)
+    {
+        if (strokeIncrement <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(strokeIncrement), strokeIncrement, "Stroke increment must be positive.");
+        }
+
+        if (penaltyStrokes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(penaltyStrokes), penaltyStrokes, "Penalty strokes cannot be negative.");
+        }
+
+        this.StrokeIncrement = strokeIncrement;
+        this.PenaltyStrokes = penaltyStrokes;
+        this.Distance = distance;
+        this.Lateral = lateral;
+        this.NewLie = newLie;
+        this.NewRemaining = Math.Max(0, newRemaining);
+        this.Holed = holed;
+        this.Commentary = commentary;
+    }
+
+    /// <summary>Gets the number of strokes added by the shot.</summary>
+    public int StrokeIncrement { get; }
+
+    /// <summary>Gets the penalty strokes incurred by the shot.</summary>
+    public int PenaltyStrokes { get; }
+
+    /// <summary>Gets the distance travelled in yards.</summary>
+    public double Distance { get; }
+
+    /// <summary>Gets the lateral description (e.g., fade, draw).</summary>
+    public string Lateral { get; }
+
+    /// <summary>Gets the new lie after the shot.</summary>
+    public Lie NewLie { get; }
+
+    /// <summary>Gets the remaining distance in yards.</summary>
+    public double NewRemaining { get; }
+
+    /// <summary>Gets a value indicating whether the shot holed out.</summary>
+    public bool Holed { get; }
+
+    /// <summary>Gets the commentary describing the outcome.</summary>
+    public string Commentary { get; }
+}

--- a/tests/FairwayQuest.Tests/FairwayQuest.Tests.csproj
+++ b/tests/FairwayQuest.Tests/FairwayQuest.Tests.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\FairwayQuest.Core\FairwayQuest.Core.csproj" />
     <ProjectReference Include="..\..\src\FairwayQuest.Courses\FairwayQuest.Courses.csproj" />
+    <ProjectReference Include="..\..\src\FairwayQuest.Cli\FairwayQuest.Cli.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />

--- a/tests/FairwayQuest.Tests/GlobalSuppressions.cs
+++ b/tests/FairwayQuest.Tests/GlobalSuppressions.cs
@@ -1,0 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "SA1600:Elements should be documented", Justification = "Test names describe scenarios clearly.")]
+[assembly: SuppressMessage("Performance", "CA1861:Prefer 'static readonly' fields over constant array arguments", Justification = "Test data arrays are tiny and defined inline for readability.")]

--- a/tests/FairwayQuest.Tests/Round/RoundSimulationTests.cs
+++ b/tests/FairwayQuest.Tests/Round/RoundSimulationTests.cs
@@ -1,0 +1,114 @@
+namespace FairwayQuest.Tests.Round;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FairwayQuest.Cli;
+using FairwayQuest.Cli.Round;
+using FairwayQuest.Core.Gameplay;
+using FairwayQuest.Core.Models;
+using FairwayQuest.Core.Scoring;
+using FairwayQuest.Core.Shots;
+using FairwayQuest.Tests.Support;
+using FluentAssertions;
+using Xunit;
+
+public sealed class RoundSimulationTests
+{
+    [Fact]
+    public void EndToEndSingleHole()
+    {
+        var hole = CreateHole(1, 4, 360, 360);
+        var player = new Player("Solo", 12, "Blue", 10, new[] { 1 });
+        var state = new PlayerHoleState(360);
+        var engine = new ShotEngine();
+        var rng = new SeedRandomProvider(123);
+
+        foreach (var club in new[] { "d", "7i", "pw", "p" })
+        {
+            var result = engine.Execute(new ShotRequest(state.Lie, state.RemainingYards, club), rng);
+            state.ApplyShot(result);
+        }
+
+        state.IsHoled.Should().BeTrue();
+        var gross = state.GrossStrokes;
+        var score = ScoreCalculator.CalculateStableford(hole.Par, gross, player.AllocatedStrokesPerHole[0]);
+        score.StablefordPoints.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void MultiPlayerTurnOrder()
+    {
+        var course = CreateCourseWithUniformYards(50, 50);
+        var hole = course.Holes[0];
+        var players = new List<Player>
+        {
+            new Player("A", 5, "Blue", 0, new[] { 0 }),
+            new Player("B", 7, "Blue", 0, new[] { 0 }),
+        };
+
+        var round = new Round(course, new[] { hole }, players, GameFormat.StrokePlay);
+        var selector = new RecordingShotSelector(new[] { "pw", "pw", "p", "p" });
+        var rng = new SequenceRandomProvider(new[]
+        {
+            0.5, 0.1, 0.05, 0.5, 0.2, 0.4,
+            0.5, 0.1, 0.05, 0.5, 0.2, 0.4,
+            0.2,
+            0.2,
+        });
+
+        var runner = new RoundRunner(round, new ShotEngine(), rng, new AppOptions(), shotSelector: selector);
+        var trackers = runner.PlayRound();
+
+        selector.Calls.Select(call => call.Player).Should().Equal("A", "B", "A", "B");
+        trackers.Select(t => t.GrossPerHole.Single()).Should().OnlyContain(strokes => strokes > 0);
+    }
+
+    [Fact]
+    public void CourseSelectionHonoursPlayerTeeYardage()
+    {
+        var course = CreateCourseWithUniformYards(300, 280);
+        var hole = course.Holes[0];
+        var players = new List<Player>
+        {
+            new Player("BluePlayer", 10, "Blue", 0, new[] { 0 }),
+            new Player("WhitePlayer", 10, "White", 0, new[] { 0 }),
+        };
+
+        var selector = new RecordingShotSelector(new[] { "p", "p" });
+        var rng = new SequenceRandomProvider(new[] { 0.1, 0.1 });
+        var round = new Round(course, new[] { hole }, players, GameFormat.StrokePlay);
+        var runner = new RoundRunner(round, new ShotEngine(), rng, new AppOptions(), shotSelector: selector);
+        runner.PlayRound();
+
+        selector.Calls.Should().HaveCount(2);
+        selector.Calls[0].Remaining.Should().Be(300);
+        selector.Calls[1].Remaining.Should().Be(280);
+    }
+
+    private static Course CreateCourseWithUniformYards(int blue, int white)
+    {
+        var holes = Enumerable.Range(1, 9)
+            .Select(i => CreateHole(i, 4, blue, white))
+            .ToList();
+
+        var tees = new Dictionary<string, TeeMetadata>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Blue"] = new TeeMetadata(70, 120),
+            ["White"] = new TeeMetadata(69, 115),
+        };
+
+        return new Course("Test Course", "Testville", holes, "Blue", tees);
+    }
+
+    private static Hole CreateHole(int number, int par, int blueYards, int whiteYards)
+    {
+        var yards = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Blue"] = blueYards,
+            ["White"] = whiteYards,
+        };
+
+        return new Hole(number, par, new StrokeIndexSet(number, number), yards);
+    }
+}

--- a/tests/FairwayQuest.Tests/Shots/ShotEngineTests.cs
+++ b/tests/FairwayQuest.Tests/Shots/ShotEngineTests.cs
@@ -1,0 +1,60 @@
+namespace FairwayQuest.Tests.Shots;
+
+using FairwayQuest.Core.Shots;
+using FairwayQuest.Tests.Support;
+using FluentAssertions;
+using Xunit;
+
+public sealed class ShotEngineTests
+{
+    private readonly ShotEngine engine = new();
+
+    [Fact]
+    public void ShotEngineDeterminism()
+    {
+        var request = new ShotRequest(Lie.Fairway, 160, "7i");
+        var first = engine.Execute(request, new SeedRandomProvider(123));
+        var second = engine.Execute(request, new SeedRandomProvider(123));
+
+        first.Lateral.Should().Be(second.Lateral);
+        first.NewLie.Should().Be(second.NewLie);
+        first.NewRemaining.Should().BeApproximately(second.NewRemaining, 0.01);
+    }
+
+    [Fact]
+    public void LieModifiersApplied()
+    {
+        var sequence = new[] { 0.5, 0.1, 0.05, 0.5, 0.2, 0.4 };
+        var fairway = engine.Execute(new ShotRequest(Lie.Fairway, 150, "7i"), new SequenceRandomProvider(sequence));
+        var rough = engine.Execute(new ShotRequest(Lie.Rough, 150, "7i"), new SequenceRandomProvider(sequence));
+
+        rough.Distance.Should().BeLessThan(fairway.Distance);
+    }
+
+    [Fact]
+    public void PuttingBands_InsideTwoYardsPrefersSinglePutt()
+    {
+        var result = engine.Execute(new ShotRequest(Lie.Green, 1.5, "p"), new SequenceRandomProvider(new[] { 0.1 }));
+        result.StrokeIncrement.Should().Be(1);
+    }
+
+    [Fact]
+    public void PuttingBands_LongPuttsTakeMultipleStrokes()
+    {
+        var twoPutt = engine.Execute(new ShotRequest(Lie.Green, 10, "p"), new SequenceRandomProvider(new[] { 0.2 }));
+        var threePutt = engine.Execute(new ShotRequest(Lie.Green, 10, "p"), new SequenceRandomProvider(new[] { 0.9 }));
+
+        twoPutt.StrokeIncrement.Should().BeGreaterThanOrEqualTo(2);
+        threePutt.StrokeIncrement.Should().BeGreaterThanOrEqualTo(2);
+        threePutt.StrokeIncrement.Should().BeLessThanOrEqualTo(3);
+    }
+
+    [Fact]
+    public void PenaltyHandling_ReturnsPenaltyStrokeAndNoProgress()
+    {
+        var result = engine.Execute(new ShotRequest(Lie.Tee, 360, "d"), new SequenceRandomProvider(new[] { 0.001 }));
+        result.PenaltyStrokes.Should().Be(1);
+        result.NewRemaining.Should().Be(360);
+        result.Holed.Should().BeFalse();
+    }
+}

--- a/tests/FairwayQuest.Tests/Support/RecordingShotSelector.cs
+++ b/tests/FairwayQuest.Tests/Support/RecordingShotSelector.cs
@@ -1,0 +1,26 @@
+namespace FairwayQuest.Tests.Support;
+
+using System.Collections.Generic;
+using FairwayQuest.Cli.Round;
+using FairwayQuest.Core.Gameplay;
+using FairwayQuest.Core.Models;
+
+internal sealed class RecordingShotSelector : IShotSelector
+{
+    private readonly Queue<string> clubs;
+    private readonly List<(string Player, double Remaining)> calls = new();
+
+    public RecordingShotSelector(IEnumerable<string> clubs)
+    {
+        this.clubs = new Queue<string>(clubs);
+    }
+
+    public IReadOnlyList<(string Player, double Remaining)> Calls => calls;
+
+    public string SelectClub(Player player, Hole hole, PlayerHoleState state)
+    {
+        var club = clubs.Dequeue();
+        calls.Add((player.Name, state.RemainingYards));
+        return club;
+    }
+}

--- a/tests/FairwayQuest.Tests/Support/SeedRandomProvider.cs
+++ b/tests/FairwayQuest.Tests/Support/SeedRandomProvider.cs
@@ -1,0 +1,28 @@
+namespace FairwayQuest.Tests.Support;
+
+using System;
+using FairwayQuest.Core.Abstractions;
+
+internal sealed class SeedRandomProvider : IRandomProvider
+{
+    private readonly System.Random random;
+
+    public SeedRandomProvider(int seed)
+    {
+        random = new System.Random(seed);
+    }
+
+    public double NextDouble() => random.NextDouble();
+
+    public double NextDouble(double minInclusive, double maxInclusive)
+    {
+        if (Math.Abs(maxInclusive - minInclusive) < double.Epsilon)
+        {
+            return minInclusive;
+        }
+
+        return minInclusive + ((maxInclusive - minInclusive) * random.NextDouble());
+    }
+
+    public int NextInt(int minInclusive, int maxExclusive) => random.Next(minInclusive, maxExclusive);
+}

--- a/tests/FairwayQuest.Tests/Support/SequenceRandomProvider.cs
+++ b/tests/FairwayQuest.Tests/Support/SequenceRandomProvider.cs
@@ -1,0 +1,44 @@
+namespace FairwayQuest.Tests.Support;
+
+using System;
+using System.Collections.Generic;
+using FairwayQuest.Core.Abstractions;
+
+internal sealed class SequenceRandomProvider : IRandomProvider
+{
+    private readonly Queue<double> sequence;
+
+    public SequenceRandomProvider(IEnumerable<double> values)
+    {
+        sequence = new Queue<double>(values);
+    }
+
+    public double NextDouble()
+    {
+        if (sequence.Count == 0)
+        {
+            throw new InvalidOperationException("No random values remaining in sequence.");
+        }
+
+        return sequence.Dequeue();
+    }
+
+    public double NextDouble(double minInclusive, double maxInclusive)
+    {
+        var next = NextDouble();
+        return minInclusive + ((maxInclusive - minInclusive) * next);
+    }
+
+    public int NextInt(int minInclusive, int maxExclusive)
+    {
+        var span = maxExclusive - minInclusive;
+        if (span <= 0)
+        {
+            return minInclusive;
+        }
+
+        var value = NextDouble();
+        var scaled = (int)Math.Floor(value * span);
+        return minInclusive + Math.Clamp(scaled, 0, span - 1);
+    }
+}


### PR DESCRIPTION
## Summary
- break the shot engine workflow into focused helpers to reduce nested logic
- reorganize the CLI club advising and prompting code into shorter, single-purpose methods
- split the round runner orchestration into composable helpers for clarity

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd597bab0c83308572cf62bcba2bd8